### PR TITLE
Adds a stop icon once recording starts

### DIFF
--- a/src/components/Steps.js
+++ b/src/components/Steps.js
@@ -98,7 +98,10 @@ export function Steps(props) {
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton iconType="play" onClick={onRecord}>
+          <EuiButton
+            iconType={isRecording ? "stop" : "play"}
+            onClick={onRecord}
+          >
             {isRecording ? "Stop" : "Start"}
           </EuiButton>
         </EuiFlexItem>


### PR DESCRIPTION
Now when recording users won't see a ⏯️ icon, but a ⏹️.