### PR TITLE
chore: keep single source of step actions

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,6 @@ const MAIN_CONTROLS_MIN_WIDTH = 700;
 
 export default function App() {
   const [url, setUrl] = useState("");
-  const [currentActions, setCurrentActions] = useState([]);
   const [stepActions, setStepActions] = useState([]);
   const [result, setResult] = useState("");
   const [type, setJourneyType] = useState("inline");
@@ -31,11 +30,6 @@ export default function App() {
   };
   const onJourneyType = value => {
     setJourneyType(value);
-  };
-  const onUpdateActions = actionWithSteps => {
-    // Spread the actions array modified by the IR
-    const actions = actionWithSteps.flat();
-    if (actions.length > 0) setCurrentActions(actions);
   };
 
   const onTestRun = result => {
@@ -91,7 +85,6 @@ export default function App() {
             <Header
               url={url}
               type={type}
-              currentActions={currentActions}
               onTestRun={onTestRun}
               onJourneyType={onJourneyType}
               onUrlChange={onUrlChange}
@@ -99,21 +92,13 @@ export default function App() {
             <EuiSpacer />
             <EuiFlexGroup wrap style={{ minHeight: 500 }}>
               <EuiFlexItem style={{ minWidth: MAIN_CONTROLS_MIN_WIDTH }}>
-                <StepsMonitor
-                  url={url}
-                  type={type}
-                  currentActions={currentActions}
-                  onUpdateActions={onUpdateActions}
-                />
+                <StepsMonitor url={url} type={type} />
               </EuiFlexItem>
               <EuiFlexItem style={{ minWidth: 300 }}>
                 <TestResult result={result} />
               </EuiFlexItem>
             </EuiFlexGroup>
-            <AssertionDrawer
-              width={MAIN_CONTROLS_MIN_WIDTH}
-              onUpdateActions={onUpdateActions}
-            />
+            <AssertionDrawer width={MAIN_CONTROLS_MIN_WIDTH} />
           </RecordingContext.Provider>
         </AssertionContext.Provider>
       </StepsContext.Provider>

--- a/src/components/AssertionDrawer.js
+++ b/src/components/AssertionDrawer.js
@@ -40,7 +40,7 @@ function getInsertionIndex(step, actionIndex) {
   return i;
 }
 
-export function AssertionDrawer({ width, onUpdateActions }) {
+export function AssertionDrawer({ width }) {
   const { actions, setActions } = useContext(StepsContext);
   const {
     actionIndex,
@@ -85,7 +85,6 @@ export function AssertionDrawer({ width, onUpdateActions }) {
     });
 
     setActions(newActions);
-    onUpdateActions(newActions);
     onHideAssertionDrawer();
   }
 
@@ -134,7 +133,7 @@ export function AssertionDrawer({ width, onUpdateActions }) {
                     onClick={performSelectorLookup(setSelector)}
                   />
                 }
-                onChange={(e) => setSelector(e.target.value)}
+                onChange={e => setSelector(e.target.value)}
                 value={selector}
                 placeholder="Selector"
               />
@@ -146,7 +145,7 @@ export function AssertionDrawer({ width, onUpdateActions }) {
             title={<EuiText textAlign="right">Command</EuiText>}
             content={
               <EuiSelect
-                onChange={(e) => {
+                onChange={e => {
                   setCommandValue(e.target.value);
                 }}
                 options={COMMAND_SELECTOR_OPTIONS}
@@ -161,7 +160,7 @@ export function AssertionDrawer({ width, onUpdateActions }) {
             content={
               <EuiFieldText
                 disabled={commandValue != "textContent"}
-                onChange={(e) => {
+                onChange={e => {
                   setValue(e.target.value);
                 }}
                 value={value}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import {
   EuiButton,
   EuiFlexGroup,
@@ -10,16 +10,19 @@ import {
   EuiSelect,
 } from "@elastic/eui";
 import { RecordingContext } from "../contexts/RecordingContext";
+import { StepsContext } from "../contexts/StepsContext";
 const { ipcRenderer: ipc } = window.require("electron-better-ipc");
 
 export function Header(props) {
+  const { actions } = useContext(StepsContext);
+  const { isRecording, toggleRecording } = useContext(RecordingContext);
+
   const getCodeFromActions = async () => {
     return await ipc.callMain("actions-to-code", {
-      actions: props.currentActions,
+      actions: actions.flat(),
       isSuite: props.type == "suite",
     });
   };
-
   const onSave = async () => {
     const code = await getCodeFromActions();
     await ipc.callMain("save-file", code);
@@ -32,9 +35,6 @@ export function Header(props) {
     });
     props.onTestRun(result);
   };
-
-  const { isRecording, toggleRecording } = React.useContext(RecordingContext);
-
   const onUrlFieldKeyUp = async e => {
     if (e?.key == "Enter" && !isRecording) {
       await toggleRecording();

--- a/src/components/Steps.js
+++ b/src/components/Steps.js
@@ -13,7 +13,7 @@ import { RecordingContext } from "../contexts/RecordingContext";
 import { StepsContext } from "../contexts/StepsContext";
 const { ipcRenderer: ipc } = window.require("electron-better-ipc");
 
-export function Steps(props) {
+export function Steps() {
   const { actions, setActions } = useContext(StepsContext);
   const { toggleRecording, isRecording, isPaused, togglePause } =
     useContext(RecordingContext);
@@ -35,7 +35,6 @@ export function Steps(props) {
       flatPrevActions.length === 0 ||
       flatPrevActions.length < flatCurrActions.length
     ) {
-      props.onUpdateActions(currActions);
       return currActions;
     }
 
@@ -47,14 +46,12 @@ export function Steps(props) {
       }
       flatCurrActions[i] && mergedActions.push(flatCurrActions[i]);
     }
-    props.onUpdateActions(mergedActions);
     return generateIR(mergedActions);
   };
 
   const onStepDetailChange = (step, stepIndex) => {
     const newActions = actions.map((a, ind) => (ind === stepIndex ? step : a));
     setActions(newActions);
-    props.onUpdateActions(newActions);
   };
 
   const onStepDelete = stepIndex => {
@@ -62,8 +59,7 @@ export function Steps(props) {
       ...actions.slice(0, stepIndex),
       ...actions.slice(stepIndex + 1),
     ];
-    setActions(() => newActions);
-    props.onUpdateActions(newActions);
+    setActions(newActions);
   };
 
   return (

--- a/src/components/StepsMonitor.js
+++ b/src/components/StepsMonitor.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import {
   EuiFlexItem,
   EuiSpacer,
@@ -12,16 +12,18 @@ import {
   EuiFlexGroup,
 } from "@elastic/eui";
 import { Steps } from "./Steps";
+import { StepsContext } from "../contexts/StepsContext";
 
 const { ipcRenderer: ipc } = window.require("electron-better-ipc");
 
 export function StepsMonitor(props) {
+  const { actions } = useContext(StepsContext);
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const [code, setCode] = useState("");
 
   const showFlyout = async () => {
     const code = await ipc.callMain("actions-to-code", {
-      actions: props.currentActions,
+      actions: actions.flat(),
       isSuite: props.type == "suite",
     });
     setCode(code);
@@ -32,7 +34,7 @@ export function StepsMonitor(props) {
     <EuiFlexGroup direction="column" gutterSize="xs">
       <EuiFlexItem>
         <EuiPanel hasBorder={true} color="transparent" borderRadius="none">
-          <Steps url={props.url} onUpdateActions={props.onUpdateActions} />
+          <Steps />
           <EuiSpacer />
 
           {isFlyoutVisible && (
@@ -56,7 +58,7 @@ export function StepsMonitor(props) {
         </EuiPanel>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        {props.currentActions.length > 0 && (
+        {actions.length > 0 && (
           <div>
             <EuiButton
               iconType="eye"


### PR DESCRIPTION
+ gets rid of the extra state which is not required as its already managed by the steps context. 