### PR TITLE
fix: Disable `Test` button when no steps are recorded

### DIFF
--- a/src/components/TestResult.js
+++ b/src/components/TestResult.js
@@ -104,7 +104,7 @@ function TestButton({ disabled, onTest }) {
     <EuiButton
       aria-label={ariaLabel}
       color="primary"
-      disabled={disabled}
+      isDisabled={disabled}
       onClick={onTest}
     >
       Test


### PR DESCRIPTION
Resolves https://github.com/elastic/synthetics-recorder/issues/37.

Disables the `Test` button and provides an explanation for the disabled state in a tooltip and the button's `aria-label` .

Enabled state:

![image](https://user-images.githubusercontent.com/18429259/136848326-cbe7b37e-346b-43e9-a0b2-cee6ebb65d40.png)

Disabled state:

![Oct-11-2021 15-57-43](https://user-images.githubusercontent.com/18429259/136848504-cbb3d6ad-81c8-4002-8125-157191739a1a.gif)

