### PR TITLE
fix: Disables the `Delete Step` button during the recording session.

### DIFF
--- a/src/components/StepList/StepDetails.js
+++ b/src/components/StepList/StepDetails.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useContext, useMemo, useState } from "react";
 import {
   EuiAccordion,
   EuiButtonIcon,
@@ -10,6 +10,7 @@ import "./StepList.css";
 import { ActionDetail } from "../ActionDetail";
 import { StepAccordionTitle } from "./StepAccordionTitle";
 import "./StepDetails.css";
+import { RecordingContext } from "../../contexts/RecordingContext";
 
 function StepDetail({ step, stepIndex, onStepDetailChange }) {
   const assertionNumberTable = useMemo(() => {
@@ -60,6 +61,7 @@ function StepAccordion({
       },
     },
   } = useEuiTheme();
+  const { isRecording } = useContext(RecordingContext);
   const [isEditing, setIsEditing] = useState(false);
   const onStepTitleChange = updatedTitle => {
     onStepDetailChange(
@@ -115,9 +117,14 @@ function StepAccordion({
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiButtonIcon
-              aria-label="Delete this step"
+              aria-label={
+                isRecording
+                  ? "Delete this step. You cannot delete steps until you end the recording session."
+                  : "Delete this step."
+              }
               className="euiAccordionForm__extraAction"
               color={darkShade}
+              isDisabled={isRecording}
               iconType="trash"
               onClick={() => onStepDelete(index)}
             />


### PR DESCRIPTION
Resolves https://github.com/elastic/synthetics-recorder/issues/36.

We don't want the user to delete steps during their recording session, as this can conflict with the action objects generated and received from the backend, and cause irreconcilable differences. This PR disables that button.

_note:_ there's significant overlap between this PR and https://github.com/elastic/synthetics-recorder/pull/40. I think it would be best to refactor the tooltip/button component I created in that PR and generalize it, so we can increase the composability of that functionality and reuse for this button, and any other buttons we may want to disable in the future.

cc @liciavale do you think this method of providing a reason for the disabled state via tooltip is helpful, or is it unnecessary/disruptive to the flow?

cc @vigneshshanmugam it's ok that we continue to allow the user to delete assertions during the recording session as they only persist on the client, right?