### PR TITLE
chore: update synthetics and pin the version

### DIFF
--- a/electron/execution.js
+++ b/electron/execution.js
@@ -137,7 +137,12 @@ async function onTest(data) {
 
   try {
     const isSuite = data.isSuite;
-    const args = ["--no-headless", "--reporter=json", "--screenshots=off"];
+    const args = [
+      "--no-headless",
+      "--reporter=json",
+      "--screenshots=off",
+      "--no-throttling",
+    ];
     const filePath = join(JOURNEY_DIR, "recorded.journey.js");
     if (!isSuite) {
       args.push("--inline");

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
     "@elastic/eui": "^37.0.0",
-    "@elastic/synthetics": "^1.0.0-beta.14",
+    "@elastic/synthetics": "=1.0.0-beta.15",
     "dotenv": "^10.0.0",
     "electron-better-ipc": "^2.0.1",
     "electron-debug": "^3.2.0",


### PR DESCRIPTION
+ Updates the synthetics agent with new release and also pins the version which makes sure everyone is working with the same chromium playwright version and not get broken when a new release is done. 
+ Disables the default throttling as its painful to record the journeys. 