### PR TITLE
feat: change assertion drawer to use flyout

### DIFF
--- a/src/components/AssertionDrawer.js
+++ b/src/components/AssertionDrawer.js
@@ -1,15 +1,16 @@
 import React, { useContext } from "react";
-
 import {
   EuiButton,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFieldText,
-  EuiPanel,
   EuiSelect,
   EuiText,
   EuiTitle,
+  EuiFlyout,
+  EuiFlyoutHeader,
+  EuiFlyoutBody,
 } from "@elastic/eui";
 
 import {
@@ -18,8 +19,6 @@ import {
 } from "../common/shared";
 import { StepsContext } from "../contexts/StepsContext";
 import { AssertionContext } from "../contexts/AssertionContext";
-
-const ADD_ASSERTION_PANEL_HEIGHT = 300;
 
 function AssertionDrawerFormRow({ title, content }) {
   return (
@@ -88,99 +87,86 @@ export function AssertionDrawer({ width }) {
     onHideAssertionDrawer();
   }
 
+  if (!isVisible) return null;
+
   return (
-    <EuiPanel
-      hasBorder
-      borderRadius="none"
-      style={{
-        animationTimingFunction: "ease-in",
-        position: "fixed",
-        bottom: 0,
-        transform: `translateY(${
-          isVisible ? 0 : `${ADD_ASSERTION_PANEL_HEIGHT}px`
-        }`,
-        transition: "transform 450ms",
-        minWidth: width,
-      }}
+    <EuiFlyout
+      aria-labelledby="assertionDrawerHeader"
+      closeButtonAriaLabel="Close the create assertion dialogue."
+      ownFocus
+      onClose={onHideAssertionDrawer}
     >
-      <EuiFlexGroup justifyContent="spaceBetween">
-        <EuiFlexItem>
-          <EuiTitle size="xs">
-            <h3>Add assertion</h3>
-          </EuiTitle>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            aria-label="Close the create assertion dialogue"
-            iconType="cross"
-            onClick={onHideAssertionDrawer}
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiFlexGroup
-        direction="column"
-        style={{ marginTop: 4, marginBottom: 4 }}
-      >
-        <EuiFlexItem>
-          <AssertionDrawerFormRow
-            title={<EuiText textAlign="right">Selector</EuiText>}
-            content={
-              <EuiFieldText
-                prepend={
-                  <EuiButtonIcon
-                    aria-label="Choose the type of assertion command"
-                    iconType="search"
-                    onClick={performSelectorLookup(setSelector)}
-                  />
-                }
-                onChange={e => setSelector(e.target.value)}
-                value={selector}
-                placeholder="Selector"
-              />
-            }
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <AssertionDrawerFormRow
-            title={<EuiText textAlign="right">Command</EuiText>}
-            content={
-              <EuiSelect
-                onChange={e => {
-                  setCommandValue(e.target.value);
-                }}
-                options={COMMAND_SELECTOR_OPTIONS}
-                value={commandValue}
-              />
-            }
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <AssertionDrawerFormRow
-            title={<EuiText textAlign="right">Value</EuiText>}
-            content={
-              <EuiFieldText
-                disabled={commandValue != "textContent"}
-                onChange={e => {
-                  setValue(e.target.value);
-                }}
-                value={value}
-              />
-            }
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiFlexGroup justifyContent="flexEnd">
-        <EuiFlexItem grow={false}>
-          <EuiButton
-            disabled={!selector}
-            aria-label="Create the assertion you have defined"
-            onClick={addAssertion}
-            size="s"
-          >
-            Add
-          </EuiButton>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </EuiPanel>
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2 id="assertionDrawerHeader">Add assertion</h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody aria-label="This element contains the controls you can use to create an assertion.">
+        <EuiFlexGroup
+          direction="column"
+          style={{ marginTop: 4, marginBottom: 4 }}
+        >
+          <EuiFlexItem>
+            <AssertionDrawerFormRow
+              title={<EuiText textAlign="right">Selector</EuiText>}
+              content={
+                <EuiFieldText
+                  prepend={
+                    <EuiButtonIcon
+                      aria-label="Choose the type of assertion command"
+                      iconType="search"
+                      onClick={performSelectorLookup(setSelector)}
+                    />
+                  }
+                  onChange={e => setSelector(e.target.value)}
+                  value={selector}
+                  placeholder="Selector"
+                />
+              }
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <AssertionDrawerFormRow
+              title={<EuiText textAlign="right">Command</EuiText>}
+              content={
+                <EuiSelect
+                  onChange={e => {
+                    setCommandValue(e.target.value);
+                  }}
+                  options={COMMAND_SELECTOR_OPTIONS}
+                  value={commandValue}
+                />
+              }
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <AssertionDrawerFormRow
+              title={<EuiText textAlign="right">Value</EuiText>}
+              content={
+                <EuiFieldText
+                  disabled={commandValue != "textContent"}
+                  onChange={e => {
+                    setValue(e.target.value);
+                  }}
+                  value={value}
+                />
+              }
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiFlexGroup justifyContent="flexEnd">
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              disabled={!selector}
+              aria-label="Create the assertion you have defined"
+              onClick={addAssertion}
+              size="s"
+            >
+              Add
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutBody>
+    </EuiFlyout>
   );
 }


### PR DESCRIPTION
Resolves https://github.com/elastic/synthetics-recorder/issues/46.

We've determined that it is better to use a flyout rather than a custom drawer component. This provides more stability and decreases the maintenance burden of the codebase, and keeps the app more aligned with the overarching design goals of EUI.