### PR TITLE
feat: assertion docs link

### DIFF
--- a/src/components/AssertionDrawer.js
+++ b/src/components/AssertionDrawer.js
@@ -111,9 +111,14 @@ export function AssertionDrawer({ width }) {
         aria-label="This element contains the controls you can use to create an assertion."
         banner={
           <EuiCallOut heading="h3" iconType="iInCircle" size="s">
-            <EuiFlexGroup alignItems="center" gutterSize="xs">
+            <EuiFlexGroup
+              alignItems="baseline"
+              direction="column"
+              gutterSize="xs"
+            >
               <EuiFlexItem grow={false}>
-                Create an assertion. Learn more in the
+                Add an assertion to check additional types of functionality in
+                your monitoring script.
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiButtonEmpty
@@ -125,7 +130,7 @@ export function AssertionDrawer({ width }) {
                   )}
                   size="xs"
                 >
-                  Playwright docs
+                  Read more about assertions
                 </EuiButtonEmpty>
               </EuiFlexItem>
             </EuiFlexGroup>


### PR DESCRIPTION
Resolves https://github.com/elastic/synthetics-recorder/issues/44.

Resolves #46.

~Depends on https://github.com/elastic/synthetics-recorder/pull/48.~

Adds a callout to the assertion drawer that links to the assertion docs maintained by Playwright.

![image](https://user-images.githubusercontent.com/18429259/137524003-5b520407-852c-4f84-8068-376dfcf7a690.png)
