### PR TITLE
fix: allow shortcuts for copy/paste/edit etc

### DIFF
--- a/electron/menu.js
+++ b/electron/menu.js
@@ -15,6 +15,19 @@ function buildMenu(appName) {
       ],
     },
     {
+      label: "Edit",
+      submenu: [
+        { role: "undo" },
+        { role: "redo" },
+        { type: "separator" },
+        { role: "cut" },
+        { role: "copy" },
+        { role: "paste" },
+        { role: "delete" },
+        { role: "selectall" },
+      ],
+    },
+    {
       label: "View",
       submenu: [{ role: "reload" }, { role: "forcereload" }],
     },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
     "@elastic/eui": "^37.0.0",
-    "@elastic/synthetics": "=1.0.0-beta.15",
+    "@elastic/synthetics": "=1.0.0-beta.16",
     "dotenv": "^10.0.0",
     "electron-better-ipc": "^2.0.1",
     "electron-debug": "^3.2.0",
@@ -86,5 +86,9 @@
   },
   "browserslist": [
     "last 1 version"
-  ]
+  ],
+  "engines": {
+    "node": ">14.14.0",
+    "npm": "6"
+  }
 }


### PR DESCRIPTION
+ Allows copy pasting and other shortcuts that was missing before. 
+ fixes #43 
+ Updated synthetics to latest version which had some issues with Chrome 96 and also updated engine compatibility to be in sync with the agent. 