### PR TITLE
feat: Add initial docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Download and unpack the appropriate binary for your platform, and install it.
 
 #### Usage
 
+This section describes the basic usage of the Script Recorder.
+It explains how to start a journey and record steps, as well as testing and outputting a completed script.
+
 After starting up the application, you may input a URL.
 This URL will be the starting point of the journey script Elastic Synthetics will create.
 


### PR DESCRIPTION
Addresses https://github.com/elastic/uptime/issues/377.

Adds initial docs. This is rough copy and I am assuming we will make significant revisions. Also does not include images yet. We may want to split this into a separate file that we link to from the main README.