### PR TITLE
fix: pause button behavior when Chromium is terminated

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -76,6 +76,7 @@ export default function App() {
                   setIsRecording(true);
                   await ipc.callMain("record-journey", { url });
                   setIsRecording(false);
+                  setIsPaused(false);
                 }
               },
               isPaused,


### PR DESCRIPTION
Resolves #59.

The Pause button doesn't change back to its default state when the Chromium process is killed by the user.