### PR TITLE
Open Synthetics recorder directly from kibana via link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ journeys/*.js
 local-browsers
 .synthetics
 react-app-env.d.ts
+
 eslint-junit.xml
+.idea

--- a/package.json
+++ b/package.json
@@ -52,7 +52,14 @@
       "main": "build/electron.js"
     },
     "mac": {
-      "icon": "public/elastic.png"
+      "icon": "public/elastic.png",
+      "category": "public.app-category.developer-tools "
+    },
+    "protocols": {
+      "name": "elastic-synthetics-recorder",
+      "schemes": [
+        "elastic-synthetics-recorder"
+      ]
     },
     "win": {
       "target": "nsis",


### PR DESCRIPTION
> ⚠️ As requested by @shahzad31, I (@lucasfcosta) am now responsible for this PR, so I'll be the ones pushing commits and responding to comments in this issue.

# Summary

This PR adds the ability to open Recorder directly from Kibana (or any other website) through a link using the `elastic-synthetics-recorder-protocol`.

You could, for example, use the following `EuiLink` to open the recorder:

```
<EuiLink href={`elastic-synthetics-recorder://`}>Open Script Recorder</EuiLink>
```

> Please notice that this PR/task does not include adding the relevant links in Kibana, and that that will be covered separately in https://github.com/elastic/kibana/issues/120638.

For now, there is no way to determine that the recorder is installed or not. Therefore, users which do not have the recorder installed will see the following standard error:

![Standard error when the script is not installed](https://user-images.githubusercontent.com/3505601/142395729-b106c076-95de-41d3-98dc-72537652abf0.png)

Below is a gif of the link working:

![2021-11-17 12-15-22 2021-11-17 12_17_13](https://user-images.githubusercontent.com/3505601/142190867-c362b384-a175-456e-b98c-e8b1e57a6fc5.gif)

# How to test this PR

1. Clone this branch and package the application using `npm run package`
2. Once the application is packaged, mount its `dmg` and install the `.app` into `Applications`.
3. Create a new folder `example-folder` and add the following HTML file as `index.html` to it:
    ```
    <!DOCTYPE html>
    <html lang="en">
    <head>
      <meta charset="UTF-8">
      <title>Test Recorder Link</title>
    </head>
    <body>
      <a href="elastic-synthetics-recorder://">Open recorder</a>
    </body>
    </html>
    ```
4. Serve the HTML file in that folder using `npx http-server example-folder`
5. Access the `localhost` URL in which you're serving your file and click the `Open recorder` link. The script recorder should open.