### PR TITLE
Update play/pause functionality to match designs

### DIFF
--- a/electron/execution.js
+++ b/electron/execution.js
@@ -111,17 +111,7 @@ async function recordJourneys(data, browserWindow) {
       await browser.close().catch({});
     };
 
-    // indicates the client wants to quit the session and keep
-    // the current state
     ipc.on("stop", closeBrowser);
-
-    // indicates the client wants to quit the session and
-    // discard the current state
-    ipc.on("abort", () => {
-      closeBrowser();
-      actionListener.removeAllListeners();
-      ipc.callRenderer(browserWindow, "change", { actions: [] });
-    });
 
     await once(browser, "disconnected");
   } catch (e) {

--- a/electron/execution.js
+++ b/electron/execution.js
@@ -111,7 +111,18 @@ async function recordJourneys(data, browserWindow) {
       await browser.close().catch({});
     };
 
+    // indicates the client wants to quit the session and keep
+    // the current state
     ipc.on("stop", closeBrowser);
+
+    // indicates the client wants to quit the session and
+    // discard the current state
+    ipc.on("abort", () => {
+      closeBrowser();
+      actionListener.removeAllListeners();
+      ipc.callRenderer(browserWindow, "change", { actions: [] });
+    });
+
     await once(browser, "disconnected");
   } catch (e) {
     logger.error(e);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -170,7 +170,11 @@ export default function App() {
                 <EuiFlexItem>
                   <EuiFlexGroup direction="column">
                     <EuiFlexItem grow={false}>
-                      <Header url={url} onUrlChange={onUrlChange} />
+                      <Header
+                        url={url}
+                        onUrlChange={onUrlChange}
+                        stepCount={stepActions.length}
+                      />
                     </EuiFlexItem>
                     <EuiFlexItem style={{ minWidth: MAIN_CONTROLS_MIN_WIDTH }}>
                       <StepsMonitor />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,6 +95,12 @@ export default function App() {
         <AssertionContext.Provider value={assertionDrawerUtils}>
           <RecordingContext.Provider
             value={{
+              abortSession: async () => {
+                if (!isRecording) return;
+                await ipc.send("abort");
+                setIsRecording(false);
+                setIsPaused(false);
+              },
               isRecording,
               toggleRecording: async () => {
                 if (isRecording) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,9 +97,10 @@ export default function App() {
             value={{
               abortSession: async () => {
                 if (!isRecording) return;
-                await ipc.send("abort");
+                await ipc.send("close");
                 setIsRecording(false);
                 setIsPaused(false);
+                setStepActions([]);
               },
               isRecording,
               toggleRecording: async () => {

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -1,0 +1,81 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import { render } from "@testing-library/react";
+import React from "react";
+import {
+  IRecordingContext,
+  RecordingContext,
+} from "../contexts/RecordingContext";
+import { Header } from "./Header";
+
+describe("<Header />", () => {
+  let isPaused = false;
+  let isRecording = false;
+  let contextValues: IRecordingContext;
+
+  beforeEach(() => {
+    contextValues = {
+      isPaused,
+      isRecording,
+      abortSession: jest.fn(),
+      togglePause: jest.fn().mockImplementation(() => (isPaused = !isPaused)),
+      toggleRecording: jest.fn().mockImplementation(() => {
+        console.log("i run");
+        isRecording = !isRecording;
+      }),
+    };
+  });
+
+  const START_BUTTON_ARIA =
+    "Toggle the script recorder between recording and paused";
+
+  const componentToRender = (overrides?: Partial<IRecordingContext>) => (
+    <RecordingContext.Provider value={{ ...contextValues, ...overrides }}>
+      <Header onUrlChange={jest.fn()} url="https://www.elastic.co/" />
+    </RecordingContext.Provider>
+  );
+
+  it("displays start text when not recording", async () => {
+    const { getByLabelText } = render(componentToRender());
+
+    expect(getByLabelText(START_BUTTON_ARIA).textContent).toBe(
+      "Start recording"
+    );
+  });
+
+  it("displays pause text when recording", () => {
+    const { getByLabelText } = render(componentToRender({ isRecording: true }));
+
+    expect(getByLabelText(START_BUTTON_ARIA).textContent).toBe("Pause");
+  });
+
+  it("displays resume text when paused", () => {
+    const { getByLabelText } = render(
+      componentToRender({ isRecording: true, isPaused: true })
+    );
+
+    expect(getByLabelText(START_BUTTON_ARIA).textContent).toBe("Resume");
+  });
+});

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -34,7 +34,7 @@ import {
 import { RecordingContext } from "../contexts/RecordingContext";
 import { StartOverWarningModal } from "./StartOverWarningModal";
 
-interface IHeader {
+export interface IHeader {
   onUrlChange: (url: string) => void;
   stepCount: number;
   url: string;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -32,13 +32,16 @@ import {
   useEuiTheme,
 } from "@elastic/eui";
 import { RecordingContext } from "../contexts/RecordingContext";
+import { StartOverWarningModal } from "./StartOverWarningModal";
 
 interface IHeader {
   onUrlChange: (url: string) => void;
+  stepCount: number;
   url: string;
 }
 
 export function Header(props: IHeader) {
+  const [isModalVisible, setIsModalVisible] = useState(false);
   const { abortSession, isRecording, isPaused, togglePause, toggleRecording } =
     useContext(RecordingContext);
 
@@ -50,8 +53,21 @@ export function Header(props: IHeader) {
 
   const urlRef = useRef<null | HTMLInputElement>(null);
 
+  const startOver = React.useCallback(async () => {
+    await abortSession();
+    setIsModalVisible(false);
+    if (urlRef) urlRef.current?.focus();
+  }, [abortSession]);
+
   return (
     <>
+      {isModalVisible && (
+        <StartOverWarningModal
+          close={() => setIsModalVisible(false)}
+          startOver={startOver}
+          stepCount={props.stepCount}
+        />
+      )}
       <EuiFlexGroup wrap gutterSize="s">
         <EuiFlexItem>
           <EuiFieldText
@@ -80,9 +96,10 @@ export function Header(props: IHeader) {
             disabled={!isRecording}
             color="primary"
             iconType="refresh"
-            onClick={async () => {
-              await abortSession();
-              if (urlRef) urlRef.current?.focus();
+            onClick={() => {
+              if (!isModalVisible) {
+                setIsModalVisible(true);
+              }
             }}
           >
             Start over

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import {
   EuiButton,
   EuiButtonIcon,
@@ -39,7 +39,7 @@ interface IHeader {
 }
 
 export function Header(props: IHeader) {
-  const { isRecording, isPaused, toggleRecording, togglePause } =
+  const { abortSession, isRecording, isPaused, togglePause, toggleRecording } =
     useContext(RecordingContext);
 
   const onUrlFieldKeyUp = async (e: React.KeyboardEvent) => {
@@ -47,6 +47,8 @@ export function Header(props: IHeader) {
       await toggleRecording();
     }
   };
+
+  const urlRef = useRef<null | HTMLInputElement>(null);
 
   return (
     <>
@@ -58,28 +60,32 @@ export function Header(props: IHeader) {
             onKeyUp={onUrlFieldKeyUp}
             onChange={e => props.onUrlChange(e.target.value)}
             fullWidth
+            inputRef={urlRef}
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <ControlButton
-            aria-label="Toggle script recording on/off"
+            aria-label="Toggle the script recorder between recording and paused"
             fill
             color="primary"
-            iconType={isRecording ? "stop" : "play"}
-            onClick={toggleRecording}
+            iconType={isRecording ? "pause" : "play"}
+            onClick={!isRecording ? toggleRecording : togglePause}
           >
-            {isRecording ? "Stop" : "Start recording"}
+            {isRecording ? (isPaused ? "Resume" : "Pause") : "Start recording"}
           </ControlButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <ControlButton
-            aria-label="Toggle script recording pause/continue"
+            aria-label="Stop recording and clear all recorded actions"
             disabled={!isRecording}
             color="primary"
-            iconType={isPaused ? "play" : "pause"}
-            onClick={togglePause}
+            iconType="refresh"
+            onClick={async () => {
+              await abortSession();
+              if (urlRef) urlRef.current?.focus();
+            }}
           >
-            {isPaused ? "Resume" : "Pause"}
+            Start over
           </ControlButton>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/src/components/StartOverWarningModal.tsx
+++ b/src/components/StartOverWarningModal.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+} from "@elastic/eui";
+import { Setter } from "../common/types";
+
+interface Props {
+  close: Setter<boolean>;
+  startOver: () => void;
+  stepCount: number;
+}
+
+function headerCopy(n: number) {
+  const step = n === 1 ? "step" : "steps";
+  return `Delete ${n} ${step}?`;
+}
+
+export function StartOverWarningModal({
+  close: setVisibility,
+  startOver,
+  stepCount,
+}: Props) {
+  if (stepCount < 1) return null;
+  const close = () => setVisibility(false);
+  return (
+    <EuiModal onClose={close}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          <h3>{headerCopy(stepCount)}</h3>
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>This action cannot be undone.</EuiModalBody>
+      <EuiModalFooter>
+        <EuiButtonEmpty onClick={close}>Cancel</EuiButtonEmpty>
+        <EuiButton color="danger" fill onClick={startOver}>
+          Delete and start over
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+}

--- a/src/components/Steps.tsx
+++ b/src/components/Steps.tsx
@@ -22,8 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import React from "react";
-import { useContext } from "react";
+import React, { useContext } from "react";
 import { EuiCode, EuiEmptyPrompt, EuiSpacer, EuiTitle } from "@elastic/eui";
 
 import { StepAccordions } from "./StepList/StepDetails";

--- a/src/contexts/RecordingContext.ts
+++ b/src/contexts/RecordingContext.ts
@@ -28,11 +28,32 @@ function notImplemented() {
   throw Error("Recording context not initialized");
 }
 
+/**
+ * Exposes functions and flags for the purpose of controlling
+ * a browser recording session.
+ */
 export interface IRecordingContext {
+  /**
+   * Messages the main process to stop the recording, discards
+   * the actions the user has recorded.
+   */
   abortSession: () => Promise<void>;
+  /**
+   * Is a recording session paused.
+   */
   isPaused: boolean;
+  /**
+   * Is there a recording session taking place.
+   */
   isRecording: boolean;
+  /**
+   * Pauses or unpauses a recording session. If the user
+   * is not recording, nothing happens.
+   */
   togglePause: () => void;
+  /**
+   * Starts or stops a recording session.
+   */
   toggleRecording: () => void;
 }
 

--- a/src/contexts/RecordingContext.ts
+++ b/src/contexts/RecordingContext.ts
@@ -28,7 +28,8 @@ function notImplemented() {
   throw Error("Recording context not initialized");
 }
 
-interface IRecordingContext {
+export interface IRecordingContext {
+  abortSession: () => Promise<void>;
   isPaused: boolean;
   isRecording: boolean;
   togglePause: () => void;
@@ -36,6 +37,9 @@ interface IRecordingContext {
 }
 
 export const RecordingContext = createContext<IRecordingContext>({
+  abortSession: async function () {
+    throw Error("RecordingContext abort session not implemented");
+  },
   isPaused: false,
   isRecording: false,
   togglePause: notImplemented,


### PR DESCRIPTION
Resolves https://github.com/elastic/synthetics-recorder/issues/96.

Modifies the Play/Pause functionality to share the same button. Updates stop functionality to depend on chromium process ending. Adds new "start over" abort functionality.

As pictured below, the user can now "start over", which will cause the main process to kill the recording session and emit an empty set of steps for the UI to display. It also causes the front-end to re-focus the URL input. They can then modify the URL if they so choose and start a new recording session. There's a modal that requires confirmation before taking the destructive action of deleting all of the steps they've previously recorded.


![20211130132801](https://user-images.githubusercontent.com/18429259/144106444-5d39523d-feae-458b-9507-cd1d1e8320d8.gif)