### PR TITLE
Use plugins instead of deprecated `rulesdir` option for linting licenses

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
   },
   extends: ["react-app", "plugin:react/recommended"],
   ignorePatterns: ["build", "local-browsers"],
+  plugins: ["custom-eslint-rules"],
   overrides: [
     {
       extends: ["eslint:recommended"],
@@ -60,7 +61,7 @@ module.exports = {
   ],
   rules: {
     "default-case": 0,
-    "require-license-header": [
+    "custom-eslint-rules/require-license-header": [
       "error",
       {
         license: LICENSE_HEADER,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "pack": "npm run build && electron-builder",
     "release": "npm run build && electron-builder -mwl --publish=always",
     "clean": "rm -rf ./build && rm -rf ./dist",
-    "lint": "eslint . --format eslint-formatter-multiple --rulesdir scripts/eslint-rules",
+    "lint": "eslint . --format eslint-formatter-multiple",
     "lint:fix": "npm run lint -- --fix",
     "test": "jest"
   },
@@ -74,6 +74,7 @@
     "electron-builder": "^22.11.7",
     "eslint": "^7.32.0",
     "eslint-formatter-multiple": "^1.0.0",
+    "eslint-plugin-custom-eslint-rules": "file:scripts/eslint-rules",
     "jest": "^26.6.0",
     "react-scripts": "^4.0.3",
     "ts-jest": "^26.5.6",

--- a/scripts/eslint-rules/require-license-header.js
+++ b/scripts/eslint-rules/require-license-header.js
@@ -39,91 +39,95 @@ function isHashbang(text) {
  * https://github.com/elastic/kibana/blob/8c07eb94e76e1d789356613563692427316f95bc/packages/kbn-eslint-plugin-eslint/rules/require_license_header.js
  */
 module.exports = {
-  meta: {
-    fixable: "code",
-    schema: [
-      {
-        type: "object",
-        properties: {
-          license: {
-            type: "string",
+  rules: {
+    "require-license-header" : {
+      meta: {
+        fixable: "code",
+        schema: [
+          {
+            type: "object",
+            properties: {
+              license: {
+                type: "string",
+              },
+            },
+            additionalProperties: false,
           },
-        },
-        additionalProperties: false,
+        ],
       },
-    ],
-  },
-  create: context => {
-    return {
-      Program() {
-        const options = context.options[0] || {};
-        const licenseToBeAdded = options.license;
-        assert(!!licenseToBeAdded, '"license" option is required');
+      create: context => {
+        return {
+          Program() {
+            const options = context.options[0] || {};
+            const licenseToBeAdded = options.license;
+            assert(!!licenseToBeAdded, '"license" option is required');
 
-        const parsed = parse(licenseToBeAdded, {
-          comment: true,
-        });
+            const parsed = parse(licenseToBeAdded, {
+              comment: true,
+            });
 
-        assert(
-          !parsed.body.length,
-          '"license" option must only include a single comment'
-        );
-        assert(
-          parsed.comments.length === 1,
-          '"license" option must only include a single comment'
-        );
+            assert(
+              !parsed.body.length,
+              '"license" option must only include a single comment'
+            );
+            assert(
+              parsed.comments.length === 1,
+              '"license" option must only include a single comment'
+            );
 
-        const license = {
-          source: licenseToBeAdded,
-          nodeValue: normalizeWhitespace(parsed.comments[0].value),
+            const license = {
+              source: licenseToBeAdded,
+              nodeValue: normalizeWhitespace(parsed.comments[0].value),
+            };
+            const sourceCode = context.getSourceCode();
+            const comment = sourceCode
+              .getAllComments()
+              .find(node => normalizeWhitespace(node.value) === license.nodeValue);
+
+            // no licence comment
+            if (!comment) {
+              context.report({
+                message: "File must start with a license header",
+                loc: {
+                  start: { line: 1, column: 0 },
+                  end: { line: 1, column: sourceCode.lines[0].length - 1 },
+                },
+                fix(fixer) {
+                  if (isHashbang(sourceCode.lines[0])) {
+                    return undefined;
+                  }
+                  return fixer.replaceTextRange([0, 0], license.source + "\n\n");
+                },
+              });
+              return;
+            }
+
+            // ensure there is nothing before the comment
+            const sourceBeforeNode = sourceCode
+              .getText()
+              .slice(0, sourceCode.getIndexFromLoc(comment.loc.start));
+            if (sourceBeforeNode.length && !isHashbang(sourceBeforeNode)) {
+              context.report({
+                node: comment,
+                message: "License header must be at the very beginning of the file",
+                fix(fixer) {
+                  // replace leading whitespace if possible
+                  if (sourceBeforeNode.trim() === "") {
+                    return fixer.replaceTextRange([0, sourceBeforeNode.length], "");
+                  }
+
+                  // inject content at top and remove node from current location
+                  // if removing whitespace is not possible
+                  return [
+                    fixer.remove(comment),
+                    fixer.replaceTextRange([0, 0], license.source + "\n\n"),
+                  ];
+                },
+              });
+            }
+          },
         };
-        const sourceCode = context.getSourceCode();
-        const comment = sourceCode
-          .getAllComments()
-          .find(node => normalizeWhitespace(node.value) === license.nodeValue);
-
-        // no licence comment
-        if (!comment) {
-          context.report({
-            message: "File must start with a license header",
-            loc: {
-              start: { line: 1, column: 0 },
-              end: { line: 1, column: sourceCode.lines[0].length - 1 },
-            },
-            fix(fixer) {
-              if (isHashbang(sourceCode.lines[0])) {
-                return undefined;
-              }
-              return fixer.replaceTextRange([0, 0], license.source + "\n\n");
-            },
-          });
-          return;
-        }
-
-        // ensure there is nothing before the comment
-        const sourceBeforeNode = sourceCode
-          .getText()
-          .slice(0, sourceCode.getIndexFromLoc(comment.loc.start));
-        if (sourceBeforeNode.length && !isHashbang(sourceBeforeNode)) {
-          context.report({
-            node: comment,
-            message: "License header must be at the very beginning of the file",
-            fix(fixer) {
-              // replace leading whitespace if possible
-              if (sourceBeforeNode.trim() === "") {
-                return fixer.replaceTextRange([0, sourceBeforeNode.length], "");
-              }
-
-              // inject content at top and remove node from current location
-              // if removing whitespace is not possible
-              return [
-                fixer.remove(comment),
-                fixer.replaceTextRange([0, 0], license.source + "\n\n"),
-              ];
-            },
-          });
-        }
-      },
-    };
-  },
+      }
+    }
+  }
 };


### PR DESCRIPTION
# Summary

This fixes a problem which would cause editors not to find the rule for checking file header licenses.

That problem happened because we were using the deprecated `rulesdir` option (see https://github.com/eslint/eslint/issues/2180#issuecomment-87722150).

That would cause my editor's eslint plugin to yield:

```
require-license-header: Definition for rule 'require-license-header' was not found.
```

Given the above, I've pushed a working version which uses a local plugin and therefore will get picked up by all editor plugins at [this branch](https://github.com/lucasfcosta/synthetics-recorder/tree/license-and-rules-plugin).

This is the new recommended ESLint way of doing it.