### PR TITLE
chore: ESLint warn on `console`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,7 +48,7 @@ module.exports = {
       rules: {
         "@typescript-eslint/explicit-module-boundary-types": 0,
         "@typescript-eslint/no-non-null-assertion": 0,
-        "no-console": "warn",
+        "no-console": 1,
       },
     },
   ],


### PR DESCRIPTION
Prevent [wasting reviewers' time](https://github.com/elastic/synthetics-recorder/pull/97#discussion_r760226489) by linting out `console` statements we fail to remove before opening PRs.