### PR TITLE
feat: Implement updated header UI

### DIFF
--- a/electron/execution.js
+++ b/electron/execution.js
@@ -126,7 +126,7 @@ async function onTest(data) {
     succeeded: 0,
     failed: 0,
     skipped: 0,
-    journeys: {},
+    journey: {},
   };
 
   const parseOrSkip = chunk => {
@@ -141,13 +141,17 @@ async function onTest(data) {
     switch (parsed.type) {
       case "journey/start": {
         const { journey } = parsed;
-        result.journeys[journey.name] = { status: "succeeded", steps: [] };
+        result.journey = {
+          status: "succeeded",
+          steps: [],
+          type: journey.name,
+        };
         break;
       }
       case "step/end": {
-        const { journey, step, error } = parsed;
+        const { step, error } = parsed;
         result[step.status]++;
-        result.journeys[journey.name].steps.push({
+        result.journey.steps.push({
           name: step.name,
           status: step.status,
           error,
@@ -157,7 +161,7 @@ async function onTest(data) {
       }
       case "journey/end": {
         const { journey } = parsed;
-        result.journeys[journey.name].status = journey.status;
+        result.journey.status = journey.status;
         break;
       }
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,7 @@ import { AssertionContext } from "./contexts/AssertionContext";
 import { RecordingContext } from "./contexts/RecordingContext";
 import { StepsContext } from "./contexts/StepsContext";
 import { TestContext } from "./contexts/TestContext";
-import type { ActionContext, JourneyType } from "./common/types";
+import type { ActionContext } from "./common/types";
 import { RecordingStatus } from "./common/types";
 import { useAssertionDrawer } from "./hooks/useAssertionDrawer";
 import { useSyntheticsTest } from "./hooks/useSyntheticsTest";
@@ -50,7 +50,6 @@ const MAIN_CONTROLS_MIN_WIDTH = 600;
 export default function App() {
   const [url, setUrl] = useState("");
   const [stepActions, setStepActions] = useState<ActionContext[][]>([]);
-  const [type, setJourneyType] = useState<JourneyType>("inline");
   const [recordingStatus, setRecordingStatus] = useState(
     RecordingStatus.NotRecording
   );
@@ -150,7 +149,7 @@ export default function App() {
                     </EuiFlexGroup>
                   </EuiFlexItem>
                   <EuiFlexItem style={{ minWidth: 300 }}>
-                    <TestResult setType={setJourneyType} type={type} />
+                    <TestResult />
                   </EuiFlexItem>
                 </EuiFlexGroup>
                 <AssertionDrawer />

--- a/src/common/shared.ts
+++ b/src/common/shared.ts
@@ -62,6 +62,11 @@ export const COMMAND_SELECTOR_OPTIONS = [
   },
 ];
 
+export const SYNTHETICS_DISCUSS_FORUM_URL =
+  "https://forms.gle/PzVtYoExfqQ9UMkY6";
+
+export const SMALL_SCREEN_BREAKPOINT = 850;
+
 export function performSelectorLookup(
   onSelectorChange: Setter<string | undefined>
 ) {
@@ -109,9 +114,6 @@ export function updateAction(
   });
 }
 
-export const SYNTHETICS_DISCUSS_FORUM_URL =
-  "https://forms.gle/PzVtYoExfqQ9UMkY6";
-
 export async function getCodeForResult(
   steps: ActionContext[][],
   journey: Journey | undefined
@@ -130,5 +132,3 @@ export async function getCodeForResult(
     journey.type
   );
 }
-
-export const SMALL_SCREEN_BREAKPOINT = 850;

--- a/src/common/shared.ts
+++ b/src/common/shared.ts
@@ -23,13 +23,7 @@ THE SOFTWARE.
 */
 
 import React from "react";
-import type {
-  ActionContext,
-  Journey,
-  JourneyStep,
-  JourneyType,
-  Setter,
-} from "./types";
+import type { ActionContext, Journey, JourneyType, Setter } from "./types";
 
 const { ipcRenderer: ipc } = window.require("electron-better-ipc");
 
@@ -118,45 +112,23 @@ export function updateAction(
 export const SYNTHETICS_DISCUSS_FORUM_URL =
   "https://forms.gle/PzVtYoExfqQ9UMkY6";
 
-export function combineResultJourneys(journey: Journey) {
-  const journeyArr = [];
-  if (journey.inline) {
-    journeyArr.push(journey.inline);
-  }
-  if (journey.suite) {
-    journeyArr.push(journey.suite);
-  }
-  return journeyArr;
-}
-
-function getStepActions(step: JourneyStep, currentActions: ActionContext[][]) {
-  if (!step.name) return;
-  for (let i = 0; i < currentActions.length; i++) {
-    if (
-      currentActions[i].length > 0 &&
-      currentActions[i][0].title === step.name
-    ) {
-      return currentActions[i];
-    }
-  }
-}
-
 export async function getCodeForResult(
-  actions: ActionContext[][],
-  journey: Journey | undefined,
-  type: string
-) {
+  steps: ActionContext[][],
+  journey: Journey | undefined
+): Promise<string> {
   if (!journey) return "";
-  const journeyArr = combineResultJourneys(journey);
-  const stepActions = journeyArr
-    .map(({ steps }) => {
-      for (const step of steps) {
-        return getStepActions(step, actions) ?? null;
-      }
-      return null;
-    })
-    .filter(f => f !== null);
+  const journeyStepNames = new Set(journey.steps.map(({ name }) => name));
 
-  // @ts-expect-error null elements are filtered out
-  return await getCodeFromActions(stepActions ?? [], type);
+  return await getCodeFromActions(
+    steps.filter(
+      step =>
+        step !== null &&
+        step.length > 0 &&
+        step[0].title &&
+        journeyStepNames.has(step[0].title)
+    ),
+    journey.type
+  );
 }
+
+export const SMALL_SCREEN_BREAKPOINT = 850;

--- a/src/common/shared.ts
+++ b/src/common/shared.ts
@@ -143,11 +143,11 @@ function getStepActions(step: JourneyStep, currentActions: ActionContext[][]) {
 
 export async function getCodeForResult(
   actions: ActionContext[][],
-  journeys: Journey | undefined,
+  journey: Journey | undefined,
   type: string
 ) {
-  if (!journeys) return "";
-  const journeyArr = combineResultJourneys(journeys);
+  if (!journey) return "";
+  const journeyArr = combineResultJourneys(journey);
   const stepActions = journeyArr
     .map(({ steps }) => {
       for (const step of steps) {

--- a/src/common/shared.ts
+++ b/src/common/shared.ts
@@ -160,4 +160,3 @@ export async function getCodeForResult(
   // @ts-expect-error null elements are filtered out
   return await getCodeFromActions(stepActions ?? [], type);
 }
-

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -55,17 +55,13 @@ export interface Result {
   failed: number;
   skipped: number;
   succeeded: number;
-  journeys: Journey;
+  journey: Journey;
 }
 
 export interface Journey {
-  inline?: JourneyStatus;
-  suite?: JourneyStatus;
-}
-
-export interface JourneyStatus {
   status: string;
   steps: Array<JourneyStep>;
+  type: JourneyType;
 }
 
 export type ResultCategory = "succeeded" | "failed" | "skipped";

--- a/src/components/ControlButton.tsx
+++ b/src/components/ControlButton.tsx
@@ -1,0 +1,64 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import { EuiButton, EuiButtonIcon, useEuiTheme } from "@elastic/eui";
+import React, { useEffect, useState } from "react";
+
+interface IControlButton {
+  "aria-label": string;
+  color: "primary";
+  disabled?: boolean;
+  fill?: boolean;
+  iconType: string;
+  onClick: () => void;
+}
+
+export const ControlButton: React.FC<IControlButton> = props => {
+  const [showIconOnly, setShowIconOnly] = useState(false);
+  const {
+    euiTheme: {
+      breakpoint: { l },
+    },
+  } = useEuiTheme();
+
+  useEffect(() => {
+    function evaluateSize() {
+      if (window.innerWidth >= l && showIconOnly) {
+        setShowIconOnly(false);
+      } else if (window.innerWidth < l && !showIconOnly) {
+        setShowIconOnly(true);
+      }
+    }
+    window.addEventListener("resize", evaluateSize);
+    return () => window.removeEventListener("resize", evaluateSize);
+  }, [l, showIconOnly]);
+
+  if (showIconOnly) {
+    const { children, fill, ...rest } = props;
+    return (
+      <EuiButtonIcon display={fill ? "fill" : "base"} size="m" {...rest} />
+    );
+  }
+  return <EuiButton {...props} />;
+};

--- a/src/components/ExportScriptButton.tsx
+++ b/src/components/ExportScriptButton.tsx
@@ -1,0 +1,43 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import { EuiButton } from "@elastic/eui";
+import React, { useContext } from "react";
+import { getCodeFromActions } from "../common/shared";
+import { StepsContext } from "../contexts/StepsContext";
+
+const { ipcRenderer: ipc } = window.require("electron-better-ipc");
+
+export function SaveCodeButton() {
+  const { actions } = useContext(StepsContext);
+  const onSave = async () => {
+    const codeFromActions = await getCodeFromActions(actions, "inline");
+    await ipc.callMain("save-file", codeFromActions);
+  };
+  return (
+    <EuiButton fill color="primary" iconType="exportAction" onClick={onSave}>
+      Export script
+    </EuiButton>
+  );
+}

--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -35,7 +35,7 @@ import { TestContext } from "../../contexts/TestContext";
 import { ControlButton } from "../ControlButton";
 import { SaveCodeButton } from "../ExportScriptButton";
 import { TestButton } from "../TestButton";
-import { RecordingHealth } from "./StatusIndicator";
+import { RecordingStatusIndicator } from "./StatusIndicator";
 
 interface IHeaderControls {
   hasActions: boolean;
@@ -75,7 +75,7 @@ export function HeaderControls({
         </ControlButton>
       </EuiFlexItem>
       <EuiFlexItem>
-        <RecordingHealth status={recordingStatus} />
+        <RecordingStatusIndicator status={recordingStatus} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiFlexGroup gutterSize="m">

--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -26,29 +26,16 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiButton,
-  EuiHealth,
   useEuiTheme,
 } from "@elastic/eui";
 import React, { useContext } from "react";
-import { Setter } from "../../common/types";
+import { RecordingStatus, Setter } from "../../common/types";
 import { RecordingContext } from "../../contexts/RecordingContext";
 import { TestContext } from "../../contexts/TestContext";
 import { ControlButton } from "../ControlButton";
 import { SaveCodeButton } from "../ExportScriptButton";
 import { TestButton } from "../TestButton";
-
-interface IRecordingHealth {
-  isPaused: boolean;
-  isRecording: boolean;
-}
-
-function RecordingHealth({ isPaused, isRecording }: IRecordingHealth) {
-  if (isRecording && !isPaused)
-    return <EuiHealth color="danger">Recording</EuiHealth>;
-  if (isRecording && isPaused)
-    return <EuiHealth color="warning">Recording paused</EuiHealth>;
-  return <EuiHealth color="subdued">Not recording</EuiHealth>;
-}
+import { RecordingHealth } from "./StatusIndicator";
 
 interface IHeaderControls {
   hasActions: boolean;
@@ -60,8 +47,7 @@ export function HeaderControls({
   setIsCodeFlyoutVisible,
 }: IHeaderControls) {
   const { euiTheme } = useEuiTheme();
-  const { isPaused, isRecording, toggleRecording } =
-    useContext(RecordingContext);
+  const { recordingStatus, toggleRecording } = useContext(RecordingContext);
   const { onTest } = useContext(TestContext);
   return (
     <EuiFlexGroup
@@ -78,14 +64,18 @@ export function HeaderControls({
         <ControlButton
           aria-label="Toggle script recording on/off"
           color="primary"
-          iconType={isRecording ? "stop" : "play"}
+          iconType={
+            recordingStatus === RecordingStatus.Recording ? "stop" : "play"
+          }
           onClick={toggleRecording}
         >
-          {isRecording ? "Stop" : "Start recording"}
+          {recordingStatus === RecordingStatus.Recording
+            ? "Stop"
+            : "Start recording"}
         </ControlButton>
       </EuiFlexItem>
       <EuiFlexItem>
-        <RecordingHealth isPaused={isPaused} isRecording={isRecording} />
+        <RecordingHealth status={recordingStatus} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiFlexGroup gutterSize="m">

--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -1,0 +1,118 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiButton,
+  EuiHealth,
+  useEuiTheme,
+} from "@elastic/eui";
+import React, { useContext } from "react";
+import { Setter } from "../../common/types";
+import { RecordingContext } from "../../contexts/RecordingContext";
+import { TestContext } from "../../contexts/TestContext";
+import { ControlButton } from "../ControlButton";
+import { SaveCodeButton } from "../ExportScriptButton";
+import { TestButton } from "../TestButton";
+
+interface IRecordingHealth {
+  isPaused: boolean;
+  isRecording: boolean;
+}
+
+function RecordingHealth({ isPaused, isRecording }: IRecordingHealth) {
+  if (isRecording && !isPaused)
+    return <EuiHealth color="danger">Recording</EuiHealth>;
+  if (isRecording && isPaused)
+    return <EuiHealth color="warning">Recording paused</EuiHealth>;
+  return <EuiHealth color="subdued">Not recording</EuiHealth>;
+}
+
+interface IHeaderControls {
+  hasActions: boolean;
+  setIsCodeFlyoutVisible: Setter<boolean>;
+}
+
+export function HeaderControls({
+  hasActions: disabled,
+  setIsCodeFlyoutVisible,
+}: IHeaderControls) {
+  const { euiTheme } = useEuiTheme();
+  const { isPaused, isRecording, toggleRecording } =
+    useContext(RecordingContext);
+  const { onTest } = useContext(TestContext);
+  return (
+    <EuiFlexGroup
+      alignItems="center"
+      gutterSize="m"
+      style={{
+        backgroundColor: euiTheme.colors.lightestShade,
+        borderBottom: euiTheme.border.thin,
+        margin: "0px 0px 4px 0px",
+        padding: 8,
+      }}
+    >
+      <EuiFlexItem grow={false}>
+        <ControlButton
+          aria-label="Toggle script recording on/off"
+          color="primary"
+          iconType={isRecording ? "stop" : "play"}
+          onClick={toggleRecording}
+        >
+          {isRecording ? "Stop" : "Start recording"}
+        </ControlButton>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <RecordingHealth isPaused={isPaused} isRecording={isRecording} />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiFlexGroup gutterSize="m">
+          <EuiFlexItem>
+            <TestButton disabled={disabled} onTest={onTest} />
+          </EuiFlexItem>
+          <EuiFlexItem
+            style={{
+              borderRight: euiTheme.border.thin,
+              paddingRight: 16,
+            }}
+          >
+            <EuiButton
+              color="text"
+              iconType="editorCodeBlock"
+              onClick={async function () {
+                setIsCodeFlyoutVisible(true);
+              }}
+            >
+              View code
+            </EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <SaveCodeButton />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/src/components/Header/StatusIndicator.tsx
+++ b/src/components/Header/StatusIndicator.tsx
@@ -1,0 +1,39 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import { EuiHealth } from "@elastic/eui";
+import React from "react";
+import { RecordingStatus } from "../../common/types";
+
+interface IRecordingHealth {
+  status: RecordingStatus;
+}
+
+export function RecordingHealth({ status }: IRecordingHealth) {
+  if (status === RecordingStatus.Recording)
+    return <EuiHealth color="danger">Recording</EuiHealth>;
+  if (status === RecordingStatus.Paused)
+    return <EuiHealth color="warning">Recording paused</EuiHealth>;
+  return <EuiHealth color="subdued">Not recording</EuiHealth>;
+}

--- a/src/components/Header/StatusIndicator.tsx
+++ b/src/components/Header/StatusIndicator.tsx
@@ -30,7 +30,7 @@ interface IRecordingHealth {
   status: RecordingStatus;
 }
 
-export function RecordingHealth({ status }: IRecordingHealth) {
+export function RecordingStatusIndicator({ status }: IRecordingHealth) {
   if (status === RecordingStatus.Recording)
     return <EuiHealth color="danger">Recording</EuiHealth>;
   if (status === RecordingStatus.Paused)

--- a/src/components/Header/Title.tsx
+++ b/src/components/Header/Title.tsx
@@ -42,6 +42,7 @@ export function Title() {
   return (
     <EuiPageHeader
       style={{
+        backgroundColor: euiTheme.colors.emptyShade,
         padding: 4,
         boxShadow: `0px 2px ${euiTheme.colors.lightestShade}`,
       }}

--- a/src/components/Header/Title.tsx
+++ b/src/components/Header/Title.tsx
@@ -1,0 +1,86 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import {
+  EuiBetaBadge,
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiPageHeader,
+  useEuiTheme,
+} from "@elastic/eui";
+import React from "react";
+import {
+  createExternalLinkHandler,
+  SYNTHETICS_DISCUSS_FORUM_URL,
+} from "../../common/shared";
+
+export function Title() {
+  const { euiTheme } = useEuiTheme();
+  return (
+    <EuiPageHeader
+      style={{
+        padding: 4,
+        boxShadow: `0px 2px ${euiTheme.colors.lightestShade}`,
+      }}
+      bottomBorder
+    >
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="s"
+        justifyContent="spaceBetween"
+      >
+        <EuiFlexItem grow={false}>
+          <EuiIcon size="l" type="logoElastic" />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <h1
+            style={{
+              fontSize: "16px",
+              fontWeight: "bold",
+            }}
+          >
+            Elastic Synthetics Recorder
+          </h1>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiBetaBadge label="BETA" />
+        </EuiFlexItem>
+        <EuiFlexItem />
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty
+            href={SYNTHETICS_DISCUSS_FORUM_URL}
+            iconSide="left"
+            iconType="popout"
+            key="link-to-synthetics-help"
+            onClick={createExternalLinkHandler(SYNTHETICS_DISCUSS_FORUM_URL)}
+          >
+            Send feedback
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPageHeader>
+  );
+}

--- a/src/components/StepsMonitor.tsx
+++ b/src/components/StepsMonitor.tsx
@@ -85,8 +85,6 @@ interface ICodeFlyout {
   code: string;
   setCode: Setter<string>;
   setIsFlyoutVisible: Setter<boolean>;
-  setType: Setter<JourneyType>;
-  type: JourneyType;
 }
 
 function CodeFlyout({
@@ -94,9 +92,8 @@ function CodeFlyout({
   code,
   setCode,
   setIsFlyoutVisible,
-  setType,
-  type,
 }: ICodeFlyout) {
+  const [type, setType] = useState<JourneyType>("inline");
   useEffect(() => {
     (async function getCode() {
       const codeFromActions = await getCodeFromActions(actions, type);
@@ -136,7 +133,6 @@ export function StepsMonitor({
 }: IStepsMonitor) {
   const { actions } = useContext(StepsContext);
   const [code, setCode] = useState("");
-  const [type, setType] = useState<JourneyType>("inline");
 
   return (
     <EuiPanel
@@ -153,8 +149,6 @@ export function StepsMonitor({
           code={code}
           setCode={setCode}
           setIsFlyoutVisible={setIsFlyoutVisible}
-          setType={setType}
-          type={type}
         />
       )}
     </EuiPanel>

--- a/src/components/StepsMonitor.tsx
+++ b/src/components/StepsMonitor.tsx
@@ -24,11 +24,7 @@ THE SOFTWARE.
 
 import React, { useContext, useEffect, useState } from "react";
 import {
-  EuiButton,
-  EuiButtonEmpty,
   EuiCodeBlock,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutHeader,
@@ -42,58 +38,6 @@ import { getCodeFromActions } from "../common/shared";
 import { Steps } from "./Steps";
 import { StepsContext } from "../contexts/StepsContext";
 import type { ActionContext, JourneyType, Setter } from "../common/types";
-
-const { ipcRenderer: ipc } = window.require("electron-better-ipc");
-
-interface IStepsFooter {
-  actions: ActionContext[][];
-  setCode: Setter<string>;
-  setIsFlyoutVisible: Setter<boolean>;
-  type: JourneyType;
-}
-
-function StepsFooter({
-  actions,
-  setCode,
-  setIsFlyoutVisible,
-  type,
-}: IStepsFooter) {
-  useEffect(() => {
-    (async function getCode() {
-      const codeFromActions = await getCodeFromActions(actions, type);
-      setCode(codeFromActions);
-    })();
-  }, [actions, setCode, type]);
-
-  const showFlyout = async () => {
-    setIsFlyoutVisible(true);
-  };
-
-  const onSave = async () => {
-    const codeFromActions = await getCodeFromActions(actions, "inline");
-    await ipc.callMain("save-file", codeFromActions);
-  };
-
-  return (
-    <EuiFlexGroup justifyContent="spaceBetween">
-      <EuiFlexItem grow={false}>
-        <EuiButtonEmpty
-          iconType="eye"
-          iconSide="right"
-          color="text"
-          onClick={showFlyout}
-        >
-          Show recorded code
-        </EuiButtonEmpty>
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiButton fill color="success" onClick={onSave}>
-          Export script
-        </EuiButton>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  );
-}
 
 interface IRecordedCodeTabs {
   selectedTab: JourneyType;
@@ -181,39 +125,38 @@ function CodeFlyout({
   );
 }
 
-export function StepsMonitor() {
+interface IStepsMonitor {
+  isFlyoutVisible: boolean;
+  setIsFlyoutVisible: Setter<boolean>;
+}
+
+export function StepsMonitor({
+  isFlyoutVisible,
+  setIsFlyoutVisible,
+}: IStepsMonitor) {
   const { actions } = useContext(StepsContext);
-  const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const [code, setCode] = useState("");
   const [type, setType] = useState<JourneyType>("inline");
 
   return (
-    <>
-      <EuiPanel
-        color="transparent"
-        borderRadius="none"
-        style={{ minHeight: 500 }}
-      >
-        <Steps />
-        <EuiSpacer />
+    <EuiPanel
+      color="transparent"
+      borderRadius="none"
+      style={{ minHeight: 500 }}
+    >
+      <Steps />
+      <EuiSpacer />
 
-        {isFlyoutVisible && (
-          <CodeFlyout
-            actions={actions}
-            code={code}
-            setCode={setCode}
-            setIsFlyoutVisible={setIsFlyoutVisible}
-            setType={setType}
-            type={type}
-          />
-        )}
-      </EuiPanel>
-      <StepsFooter
-        actions={actions}
-        setCode={setCode}
-        setIsFlyoutVisible={setIsFlyoutVisible}
-        type={type}
-      />
-    </>
+      {isFlyoutVisible && (
+        <CodeFlyout
+          actions={actions}
+          code={code}
+          setCode={setCode}
+          setIsFlyoutVisible={setIsFlyoutVisible}
+          setType={setType}
+          type={type}
+        />
+      )}
+    </EuiPanel>
   );
 }

--- a/src/components/TestButton.tsx
+++ b/src/components/TestButton.tsx
@@ -32,13 +32,13 @@ export function TestButton({
   disabled: boolean;
   onTest: React.MouseEventHandler<HTMLButtonElement>;
 }) {
-  const ariaLabel = disabled
-    ? "Record a step in order to run a test"
-    : "Perform a test run for the journey you have recorded";
-
   const button = (
     <EuiButton
-      aria-label={ariaLabel}
+      aria-label={
+        disabled
+          ? "Record a step in order to run a test"
+          : "Perform a test run for the journey you have recorded"
+      }
       color="primary"
       iconType="beaker"
       isDisabled={disabled}

--- a/src/components/TestButton.tsx
+++ b/src/components/TestButton.tsx
@@ -1,0 +1,60 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import { EuiButton, EuiToolTip } from "@elastic/eui";
+import React from "react";
+
+export function TestButton({
+  disabled,
+  onTest,
+}: {
+  disabled: boolean;
+  onTest: React.MouseEventHandler<HTMLButtonElement>;
+}) {
+  const ariaLabel = disabled
+    ? "Record a step in order to run a test"
+    : "Perform a test run for the journey you have recorded";
+
+  const button = (
+    <EuiButton
+      aria-label={ariaLabel}
+      color="primary"
+      iconType="beaker"
+      isDisabled={disabled}
+      onClick={onTest}
+    >
+      Replay steps
+    </EuiButton>
+  );
+
+  if (disabled) {
+    return (
+      <EuiToolTip content="Record a step in order to run a test" delay="long">
+        {button}
+      </EuiToolTip>
+    );
+  }
+
+  return button;
+}

--- a/src/components/TestResult.tsx
+++ b/src/components/TestResult.tsx
@@ -40,10 +40,8 @@ import { StepsContext } from "../contexts/StepsContext";
 import type {
   Journey,
   JourneyStep,
-  JourneyType,
   Result,
   ResultCategory,
-  Setter,
 } from "../common/types";
 import { TestContext } from "../contexts/TestContext";
 
@@ -109,12 +107,7 @@ function ResultAccordions({ codeBlocks, journey }: IResultAccordions) {
   );
 }
 
-interface ITestResult {
-  setType: Setter<JourneyType>;
-  type: JourneyType;
-}
-
-export function TestResult(props: ITestResult) {
+export function TestResult() {
   const { actions } = useContext(StepsContext);
   const { codeBlocks, result, setResult } = useContext(TestContext);
 
@@ -170,7 +163,6 @@ export function TestResult(props: ITestResult) {
         <EuiFlexGroup>
           <EuiFlexItem>
             <ResultAccordions
-              {...props}
               codeBlocks={codeBlocks}
               journey={result.journey}
             />

--- a/src/components/TestResult.tsx
+++ b/src/components/TestResult.tsx
@@ -22,10 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect } from "react";
 import {
   EuiAccordion,
-  EuiButton,
   EuiCodeBlock,
   EuiFlexGroup,
   EuiFlexItem,
@@ -34,14 +33,12 @@ import {
   EuiSpacer,
   EuiText,
   EuiTitle,
-  EuiToolTip,
   useEuiTheme,
 } from "@elastic/eui";
 
-import { getCodeFromActions } from "../common/shared";
+import { combineResultJourneys } from "../common/shared";
 import { StepsContext } from "../contexts/StepsContext";
 import type {
-  ActionContext,
   Journey,
   JourneyStep,
   JourneyType,
@@ -49,8 +46,7 @@ import type {
   ResultCategory,
   Setter,
 } from "../common/types";
-
-const { ipcRenderer: ipc } = window.require("electron-better-ipc");
+import { TestContext } from "../contexts/TestContext";
 
 const symbols: Record<ResultCategory, JSX.Element> = {
   succeeded: <EuiIcon color="success" type="check" />,
@@ -61,48 +57,6 @@ const symbols: Record<ResultCategory, JSX.Element> = {
 function removeColorCodes(str = "") {
   // eslint-disable-next-line no-control-regex
   return str.replace(/\u001b\[.*?m/g, "");
-}
-
-function getStepActions(step: JourneyStep, currentActions: ActionContext[][]) {
-  if (!step.name) return;
-  for (let i = 0; i < currentActions.length; i++) {
-    if (
-      currentActions[i].length > 0 &&
-      currentActions[i][0].title === step.name
-    ) {
-      return currentActions[i];
-    }
-  }
-}
-
-function combineResultJourneys(journey: Journey) {
-  const journeyArr = [];
-  if (journey.inline) {
-    journeyArr.push(journey.inline);
-  }
-  if (journey.suite) {
-    journeyArr.push(journey.suite);
-  }
-  return journeyArr;
-}
-
-async function getCodeForResult(
-  actions: ActionContext[][],
-  journeys: Journey,
-  type: string
-) {
-  const journeyArr = combineResultJourneys(journeys);
-  const stepActions = journeyArr
-    .map(({ steps }) => {
-      for (const step of steps) {
-        return getStepActions(step, actions) ?? null;
-      }
-      return null;
-    })
-    .filter(f => f !== null);
-
-  // @ts-expect-error null elements are filtered out
-  return await getCodeFromActions(stepActions ?? [], type);
 }
 
 interface IResultAccordions {
@@ -161,36 +115,6 @@ function ResultAccordions({ codeBlocks, journeys }: IResultAccordions) {
   );
 }
 
-function TestButton({
-  disabled,
-  onTest,
-}: {
-  disabled: boolean;
-  onTest: React.MouseEventHandler<HTMLButtonElement>;
-}) {
-  const ariaLabel = disabled
-    ? "Record a step in order to run a test"
-    : "Perform a test run for the journey you have recorded";
-  const button = (
-    <EuiButton
-      aria-label={ariaLabel}
-      color="primary"
-      isDisabled={disabled}
-      onClick={onTest}
-    >
-      Test
-    </EuiButton>
-  );
-  if (disabled) {
-    return (
-      <EuiToolTip content="Record a step in order to run a test" delay="long">
-        {button}
-      </EuiToolTip>
-    );
-  }
-  return button;
-}
-
 interface ITestResult {
   setType: Setter<JourneyType>;
   type: JourneyType;
@@ -198,12 +122,11 @@ interface ITestResult {
 
 export function TestResult(props: ITestResult) {
   const { actions } = useContext(StepsContext);
-  const [result, setResult] = useState<Result | undefined>(undefined);
-  const [codeBlocks, setCodeBlocks] = useState("");
+  const { codeBlocks, result, setResult } = useContext(TestContext);
 
   useEffect(() => {
     if (actions.length === 0 && result) setResult(undefined);
-  }, [actions.length, result]);
+  }, [actions.length, result, setResult]);
 
   const {
     euiTheme: {
@@ -224,18 +147,6 @@ export function TestResult(props: ITestResult) {
     succeeded: "success",
     failed: result?.failed === 1 ? "error" : "errors",
     skipped: "skipped",
-  };
-
-  const onTest: React.MouseEventHandler<HTMLButtonElement> = async () => {
-    const code = await getCodeFromActions(actions, props.type);
-    const resultFromServer: Result = await ipc.callMain("run-journey", {
-      code,
-      isSuite: props.type === "suite",
-    });
-    setCodeBlocks(
-      await getCodeForResult(actions, resultFromServer.journeys, props.type)
-    );
-    setResult(resultFromServer);
   };
 
   const ResultComponent = ({ result }: { result: Result }) => {
@@ -289,9 +200,6 @@ export function TestResult(props: ITestResult) {
           </EuiTitle>
         </EuiFlexItem>
         <EuiFlexItem />
-        <EuiFlexItem grow={false}>
-          <TestButton disabled={actions.length === 0} onTest={onTest} />
-        </EuiFlexItem>
       </EuiFlexGroup>
       <EuiPanel color="subdued">
         {result && <ResultComponent result={result}></ResultComponent>}

--- a/src/components/TestResult.tsx
+++ b/src/components/TestResult.tsx
@@ -36,7 +36,6 @@ import {
   useEuiTheme,
 } from "@elastic/eui";
 
-import { combineResultJourneys } from "../common/shared";
 import { StepsContext } from "../contexts/StepsContext";
 import type {
   Journey,
@@ -61,55 +60,50 @@ function removeColorCodes(str = "") {
 
 interface IResultAccordions {
   codeBlocks: string;
-  journeys: Journey;
+  journey: Journey;
 }
 
-function ResultAccordions({ codeBlocks, journeys }: IResultAccordions) {
-  const journeyArr = combineResultJourneys(journeys);
-  if (journeyArr.length === 0) return null;
-
+function ResultAccordions({ codeBlocks, journey }: IResultAccordions) {
   return (
     <>
-      {journeyArr.map(({ steps }) => {
-        return steps.map((step: JourneyStep, stepIndex: number) => {
-          const { name, status, error, duration } = step;
-          return (
-            <EuiAccordion
-              id={step.name}
-              key={stepIndex}
-              arrowDisplay="none"
-              forceState={status === "failed" ? "open" : "closed"}
-              buttonContent={
-                <EuiFlexGroup alignItems="center">
-                  <EuiFlexItem grow={false}>{symbols[status]}</EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiText size="s" style={{ fontWeight: 500 }}>
-                      {name} ({duration} ms)
-                    </EuiText>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              }
-              paddingSize="s"
-              buttonClassName="euiAccordionForm__button"
-            >
-              {error && (
-                <>
-                  <EuiCodeBlock
-                    language="js"
-                    paddingSize="m"
-                    style={{ maxWidth: 300 }}
-                    transparentBackground={true}
-                  >
-                    {codeBlocks ?? null}
-                  </EuiCodeBlock>
-                  <EuiCodeBlock paddingSize="m" transparentBackground={true}>
-                    {removeColorCodes(error.message)}
-                  </EuiCodeBlock>
-                </>
-              )}
-            </EuiAccordion>
-          );
-        });
+      {journey.steps.map((step: JourneyStep, stepIndex: number) => {
+        const { name, status, error, duration } = step;
+        return (
+          <EuiAccordion
+            id={step.name}
+            key={stepIndex}
+            arrowDisplay="none"
+            forceState={status === "failed" ? "open" : "closed"}
+            buttonContent={
+              <EuiFlexGroup alignItems="center">
+                <EuiFlexItem grow={false}>{symbols[status]}</EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiText size="s" style={{ fontWeight: 500 }}>
+                    {name} ({duration} ms)
+                  </EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            }
+            paddingSize="s"
+            buttonClassName="euiAccordionForm__button"
+          >
+            {error && (
+              <>
+                <EuiCodeBlock
+                  language="js"
+                  paddingSize="m"
+                  style={{ maxWidth: 300 }}
+                  transparentBackground={true}
+                >
+                  {codeBlocks ?? null}
+                </EuiCodeBlock>
+                <EuiCodeBlock paddingSize="m" transparentBackground={true}>
+                  {removeColorCodes(error.message)}
+                </EuiCodeBlock>
+              </>
+            )}
+          </EuiAccordion>
+        );
       })}
     </>
   );
@@ -178,7 +172,7 @@ export function TestResult(props: ITestResult) {
             <ResultAccordions
               {...props}
               codeBlocks={codeBlocks}
-              journeys={result.journeys}
+              journey={result.journey}
             />
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/src/contexts/TestContext.ts
+++ b/src/contexts/TestContext.ts
@@ -1,0 +1,48 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+import { createContext } from "react";
+import { Result, Setter } from "../common/types";
+
+function notImplemented() {
+  throw Error("Test context not initialized");
+}
+
+async function notImplementedAsync() {
+  notImplemented();
+}
+
+interface ITestContext {
+  codeBlocks: string;
+  onTest: () => Promise<void>;
+  result?: Result;
+  setCodeBlocks: Setter<string>;
+  setResult: Setter<Result | undefined>;
+}
+
+export const TestContext = createContext<ITestContext>({
+  codeBlocks: "",
+  onTest: notImplementedAsync,
+  setCodeBlocks: notImplemented,
+  setResult: notImplemented,
+});

--- a/src/hooks/useSyntheticsTest.ts
+++ b/src/hooks/useSyntheticsTest.ts
@@ -42,12 +42,11 @@ export function useSyntheticsTest(actions: ActionContext[][]) {
         code,
         isSuite: false,
       });
-      setCodeBlocks(
-        await getCodeForResult(actions, result?.journeys, "inline")
-      );
+
+      setCodeBlocks(await getCodeForResult(actions, result?.journey));
       setResult(resultFromServer);
     },
-    [result?.journeys, setCodeBlocks, setResult, actions]
+    [actions, result]
   );
   return {
     codeBlocks,

--- a/src/hooks/useSyntheticsTest.ts
+++ b/src/hooks/useSyntheticsTest.ts
@@ -1,0 +1,59 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import { useCallback, useState } from "react";
+import { getCodeForResult, getCodeFromActions } from "../common/shared";
+import { ActionContext, Result } from "../common/types";
+
+const { ipcRenderer: ipc } = window.require("electron-better-ipc");
+
+export function useSyntheticsTest(actions: ActionContext[][]) {
+  const [result, setResult] = useState<Result | undefined>(undefined);
+  const [codeBlocks, setCodeBlocks] = useState("");
+
+  const onTest = useCallback(
+    async function () {
+      /**
+       * For the time being we are only running tests as inline.
+       */
+      const code = await getCodeFromActions(actions, "inline");
+      const resultFromServer: Result = await ipc.callMain("run-journey", {
+        code,
+        isSuite: false,
+      });
+      setCodeBlocks(
+        await getCodeForResult(actions, result?.journeys, "inline")
+      );
+      setResult(resultFromServer);
+    },
+    [result?.journeys, setCodeBlocks, setResult, actions]
+  );
+  return {
+    codeBlocks,
+    result,
+    onTest,
+    setCodeBlocks,
+    setResult,
+  };
+}


### PR DESCRIPTION
Resolves #106.

First step at implementing the latest recorder designs. This updates the header to match the styling, and migrates the buttons and functionality from elsewhere in the app to be in the header.

We can hold off on merging this until the follow-up PR adding the updated body is ready. My goal with this dedicated PR is to limit the scope and review burden.