### PR TITLE
chore: Add `nodemon`

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,3 @@
+{
+  "watch": ["electron/"]
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "react:start": "react-scripts start",
     "react:build": "react-scripts build",
     "electron:copy": "cp -r ./electron/. ./build",
-    "dev": "concurrently -k \"BROWSER=none npm run react:start\" \"wait-on tcp:3000 && electron electron/electron.js\"",
+    "dev": "concurrently -k \"BROWSER=none npm run react:start\" \"wait-on tcp:3000 && nodemon --exec electron electron/electron.js\"",
     "build": "npm run clean && npm run react:build && npm run electron:copy",
     "pack": "npm run build && electron-builder",
     "release": "npm run build && electron-builder -mwl --publish=always",
@@ -82,6 +82,7 @@
     "husky": "^7.0.4",
     "jest": "^26.6.0",
     "prettier": "2.5.0",
+    "nodemon": "^2.0.15",
     "react-scripts": "^4.0.3",
     "ts-jest": "^26.5.6",
     "wait-on": "^6.0.0"


### PR DESCRIPTION
Today when we make changes to our `electron` code, we need to restart the process to see them reflected. This can be frustrating when debugging or adding new functionality.

These changes introduce `nodemon` to manage the restart for us manually when we're targeting the electron files. It shouldn't need to watch anything else since react scripts will automatically reload the frontend files for us.