### PR TITLE
Add repo-level documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -33,6 +33,7 @@ body:
       label: Recorder Version
       description: |
         Which version of the script recorder are you using?
+        You can see the recorder's version number in the "Elastic Synthetics Recorder > About" menu.
         If you're unsure, provide us with the date in which you've downloaded it (if you remember it).
       placeholder: 1.0.1
     validations:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,67 @@
+name: Bug 🐛
+description: Something is not behaving as expected.
+title: '[Bug] '
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Before creating your issue
+  - type: markdown
+    attributes:
+      value: |
+        ## Troubleshoot locally
+        Please try to ensure that the bug you're reporting is _not_ caused by any misconfiguration on your machine or network. Ideally, try to reproduce the problem on a different environment.
+  - type: markdown
+    attributes:
+      value: |
+        ## Identify the steps to reproduce the issue
+        The fewer and simpler the steps we can take to reproduce your issue, the sooner we can get back to you, and solve your problem.
+        If possible, please include a GIF or screenshots for each of the steps you followed to reproduce the bug.
+        Please provide as much relevant information as possible about your environment if you think that could be interfering with the app's behavior.
+  - type: textarea
+    id: bug_summary
+    attributes:
+      label: Bug summary
+      description: A concise description of the bug.
+      placeholder: The recorder crashed when I started recording.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Recorder Version
+      description: |
+        Which version of the script recorder are you using?
+        If you're unsure, provide us with the date in which you've downloaded it (if you remember it).
+      placeholder: 1.0.1
+    validations:
+      required: false
+  - type: textarea
+    id: how_to_reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Describe the steps to reproduce your issue.
+      placeholder: |
+        Example issue:
+        1. Start the script recorder
+        2. Type www.example.com in the main URL field
+        3. Click start recording
+        4. Do XYZ and you'll see that undesired behavior ABC happens.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Explain what should the desired behaviour be.
+      placeholder: XYZ should not appear
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional information
+      description: Any other relevant pieces of information.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,36 @@
+name: Enhancement 🚀
+description: Propose a new feature or enhancement.
+title: '[Enhancement] '
+labels: ['enhancement']
+body:
+  - type: textarea
+    id: feature_summary
+    attributes:
+      label: Feature summary
+      description: A description of the feature.
+      placeholder: I want the script recorder to be able to assert on the page's title.
+    validations:
+      required: true
+  - type: textarea
+    id: feature_reason
+    attributes:
+      label: Why is this feature important?
+      description: |
+        Explain why this feature is important for our users, or how it makes the script recorder better.
+      placeholder: Allowing the recorder to assert on the page's title is a use-case that 99% of our users have requested, as it's a crucial part of a web page.
+    validations:
+      required: false
+  - type: textarea
+    id: resources
+    attributes:
+      label: Linked resources
+      description: Link any designs or other resources which might be relevant for implementing this feature.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional information
+      description: Any other relevant pieces of information.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,27 @@
+name: Other ⚙
+description: Register a chore, or some other type of task.
+title: '[Other] '
+labels: ['chore']
+body:
+  - type: textarea
+    id: task_summary
+    attributes:
+      label: Task summary
+      description: A description of the task.
+      placeholder: We must implement the infrastructure for E2E tests.
+    validations:
+      required: true
+  - type: textarea
+    id: resources
+    attributes:
+      label: Linked resources
+      description: Link any designs or other resources which might be relevant for implementing this feature.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional information
+      description: Any other relevant pieces of information.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!-- Thanks for your pull request. Please fill all of the mandatory fields in this template. That will help us get back to you sooner. -->
+
+<!-- If it's your first time contributing to an Elastic repo, don't forget to sign our CLA at https://www.elastic.co/contributor-agreement -->
+
+
+## Summary
+
+<!-- What does this change do? Which issue does it solve? -->
+
+<!-- If you have any screenshots or GIFs, here's where you should include them. -->
+
+
+## Implementation details
+
+<!-- If you're solving a bug, what caused it, and how did you fix it? -->
+
+<!-- If you're adding a feature or implementing an enhancement, what are notable aspects about its implementation? -->
+
+
+## How to validate this change
+
+<!-- How can others validate that what you've done is correct? -->
+
+<!-- Is there any particular subject on which you need more input? -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,6 @@ When opening a pull-request, make sure to specify which issue it solves, so that
 
 Just like when opening an issue, it's important to fill all the sections in our pull-request templates appropriately, so that we can review your contribution sooner, and provide actionable feedback in less time.
 
-After your issue is opened **and CI is passing*, the team will do its best to review it and get back to you as soon as we can, although we can't commit to a specific timeframe.
+After your issue is opened **and CI is passing**, the team will do its best to review it and get back to you as soon as we can, although we can't commit to a specific timeframe.
 
 Please note that you'll have to sign [Elastic's CLA to be able to contribute code to this repo](https://www.elastic.co/contributor-agreement).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+Contributions to this repository will be very welcome, both in the form of issues or pull-requests 😊
+
+Before starting to work on a particular piece of code, please first open an issue to discuss the change before starting to work on it.
+
+Please note that Elastic does have a [Code of Conduct](https://www.elastic.co/community/codeofconduct).
+
+
+# Creating an issue
+
+We expect contributors to fill our issue templates when creating new issues. It's important that contributors use those templates appropriately because doing so helps us triage issues more quickly, discuss them more efficiently, and respond to the issue's participants sooner.
+
+For bugs, for example, we expect contributors to provide clear instructions on how to reproduce the bug they've found, and, if possible a screenshot or GIF illustrating the problem. We also appreciate it when contributors can provide information with regards to what caused the bug to occur, even though that's not necessary for reporting a bug.
+
+Once contributors create an issue, this project's maintainers will review and triage it, and we'll aim to get back to the issue's creator as soon as we can, although we can't promise any particular dates.
+
+
+# Opening a pull-request
+
+Before submitting your PR, ensure it complies with the specs in the issue you're solving, and run both the tests and linting tasks specified in `package.json`. These will run in CI anyway, so you'll have to have these tasks passing before you can merge your pull-request.
+
+When opening a pull-request, make sure to specify which issue it solves, so that the PR and issue get linked. Do the same in your commit messages by adding the issue number to it.
+
+Just like when opening an issue, it's important to fill all the sections in our pull-request templates appropriately, so that we can review your contribution sooner, and provide actionable feedback in less time.
+
+After your issue is opened **and CI is passing*, the team will do its best to review it and get back to you as soon as we can, although we can't promise dates given the team may have other priorities.
+
+Please note that you'll have to sign [Elastic's CLA to be able to contribute code to this repo](https://www.elastic.co/contributor-agreement).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,19 +11,19 @@ Please note that Elastic does have a [Code of Conduct](https://www.elastic.co/co
 
 We expect contributors to fill our issue templates when creating new issues. It's important that contributors use those templates appropriately because doing so helps us triage issues more quickly, discuss them more efficiently, and respond to the issue's participants sooner.
 
-For bugs, for example, we expect contributors to provide clear instructions on how to reproduce the bug they've found, and, if possible a screenshot or GIF illustrating the problem. We also appreciate it when contributors can provide information with regards to what caused the bug to occur, even though that's not necessary for reporting a bug.
+For bugs, for example, we expect contributors to provide clear instructions on how to reproduce the bug they've found, and, if possible a screenshot or GIF illustrating the problem. We also appreciate it when contributors can provide information about the bug's cause, even though that's not necessary for reporting a bug.
 
 Once contributors create an issue, this project's maintainers will review and triage it, and we'll aim to get back to the issue's creator as soon as we can, although we can't promise any particular dates.
 
 
 # Opening a pull-request
 
-Before submitting your PR, ensure it complies with the specs in the issue you're solving, and run both the tests and linting tasks specified in `package.json`. These will run in CI anyway, so you'll have to have these tasks passing before you can merge your pull-request.
+Before submitting your PR, ensure it complies with the specs in the issue you're solving, and run both the tests and linting tasks specified in `package.json`. These are required by CI, so they need to be passing before you can merge your pull-request.
 
 When opening a pull-request, make sure to specify which issue it solves, so that the PR and issue get linked. Do the same in your commit messages by adding the issue number to it.
 
 Just like when opening an issue, it's important to fill all the sections in our pull-request templates appropriately, so that we can review your contribution sooner, and provide actionable feedback in less time.
 
-After your issue is opened **and CI is passing*, the team will do its best to review it and get back to you as soon as we can, although we can't promise dates given the team may have other priorities.
+After your issue is opened **and CI is passing*, the team will do its best to review it and get back to you as soon as we can, although we can't commit to a specific timeframe.
 
 Please note that you'll have to sign [Elastic's CLA to be able to contribute code to this repo](https://www.elastic.co/contributor-agreement).


### PR DESCRIPTION
# Summary

This PR closes https://github.com/elastic/synthetics-recorder/issues/109 by adding the missing repo-level documentation, including:

* A small contribution guide
* Issue templates
* A pull-request template

I tried to follow a pattern similar to most open-source repos to which I contribute, and tried to use patterns which make the repo approachable for external contributors too. I've also had a look at other Elastic repos to be sure the contents here would be okay.

**NOTE**: You can validate these issue templates [here](https://github.com/lucasfcosta/synthetics-recorder/blob/repo-docs/.github/ISSUE_TEMPLATE).