### PR TITLE
[Other] Prep for release

### DIFF
--- a/jest.unit.setup.js
+++ b/jest.unit.setup.js
@@ -22,8 +22,17 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-module.exports = {
-  preset: "ts-jest",
-  testPathIgnorePatterns: [`node_modules`, `\\.cache`, `e2e`],
-  setupFilesAfterEnv: ["./jest.unit.setup.js"],
-};
+/**
+ * We do this because there are numerous places in the frontend code that
+ * need to call `window.require("electron-better-ipc"). Because the tests
+ * are not configured to run with node env features, `window.require` will
+ * not be defined.
+ *
+ * We rely on e2e testing to ensure that our communications via IPC to the
+ * electron process are working, so for the most part we can ignore this
+ * feature, and mock its responses when testing frontend functionality in
+ * unit tests. This setup will preclude the need to include the declaration
+ * of `require` on the `window` object before any test that depends on this.
+ */
+
+window.require = require;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ THE SOFTWARE.
 */
 
 import React from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { EuiFlexGroup, EuiFlexItem, EuiPageBody } from "@elastic/eui";
 import "./App.css";
 import "@elastic/eui/dist/eui_theme_amsterdam_light.css";
@@ -42,6 +42,7 @@ import { RecordingStatus } from "./common/types";
 import { useAssertionDrawer } from "./hooks/useAssertionDrawer";
 import { useSyntheticsTest } from "./hooks/useSyntheticsTest";
 import { generateIR, generateMergedIR } from "./helpers/generator";
+import { UrlContext } from "./contexts/UrlContext";
 
 const { ipcRenderer: ipc } = window.require("electron-better-ipc");
 
@@ -61,6 +62,8 @@ export default function App() {
   const onUrlChange = (value: string) => {
     setUrl(value);
   };
+
+  const urlRef = useRef(null);
 
   useEffect(() => {
     ipc.answerMain("change", ({ actions }: { actions: ActionContext[] }) => {
@@ -122,38 +125,39 @@ export default function App() {
             }}
           >
             <TestContext.Provider value={syntheticsTestUtils}>
-              <Title />
-              <HeaderControls
-                hasActions={stepActions.length === 0}
-                setIsCodeFlyoutVisible={setIsCodeFlyoutVisible}
-              />
-              <EuiPageBody>
-                <EuiFlexGroup>
-                  <EuiFlexItem>
-                    <EuiFlexGroup direction="column">
-                      <EuiFlexItem grow={false}>
-                        <Header
-                          url={url}
-                          onUrlChange={onUrlChange}
-                          stepCount={stepActions.length}
-                        />
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        style={{ minWidth: MAIN_CONTROLS_MIN_WIDTH }}
-                      >
-                        <StepsMonitor
-                          isFlyoutVisible={isCodeFlyoutVisible}
-                          setIsFlyoutVisible={setIsCodeFlyoutVisible}
-                        />
-                      </EuiFlexItem>
-                    </EuiFlexGroup>
-                  </EuiFlexItem>
-                  <EuiFlexItem style={{ minWidth: 300 }}>
-                    <TestResult />
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-                <AssertionDrawer />
-              </EuiPageBody>
+              <UrlContext.Provider value={{ urlRef }}>
+                <Title />
+                <HeaderControls
+                  setIsCodeFlyoutVisible={setIsCodeFlyoutVisible}
+                />
+                <EuiPageBody>
+                  <EuiFlexGroup>
+                    <EuiFlexItem>
+                      <EuiFlexGroup direction="column">
+                        <EuiFlexItem grow={false}>
+                          <Header
+                            url={url}
+                            onUrlChange={onUrlChange}
+                            stepCount={stepActions.length}
+                          />
+                        </EuiFlexItem>
+                        <EuiFlexItem
+                          style={{ minWidth: MAIN_CONTROLS_MIN_WIDTH }}
+                        >
+                          <StepsMonitor
+                            isFlyoutVisible={isCodeFlyoutVisible}
+                            setIsFlyoutVisible={setIsCodeFlyoutVisible}
+                          />
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiFlexItem>
+                    <EuiFlexItem style={{ minWidth: 300 }}>
+                      <TestResult />
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                  <AssertionDrawer />
+                </EuiPageBody>
+              </UrlContext.Provider>
             </TestContext.Provider>
           </RecordingContext.Provider>
         </AssertionContext.Provider>

--- a/src/common/shared.test.ts
+++ b/src/common/shared.test.ts
@@ -22,10 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-/* eslint-disable import/first */
-window.require = require;
 import { updateAction } from "./shared";
-import { ActionContext } from "./types";
+import type { ActionContext } from "./types";
 
 describe("shared", () => {
   describe("updateAction", () => {

--- a/src/components/Header/HeaderControls.test.tsx
+++ b/src/components/Header/HeaderControls.test.tsx
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import React from "react";
-import { ActionContext, RecordingStatus } from "../../common/types";
+import { RecordingStatus } from "../../common/types";
 import { UrlContext } from "../../contexts/UrlContext";
 import {
   IRecordingContext,

--- a/src/components/Header/HeaderControls.test.tsx
+++ b/src/components/Header/HeaderControls.test.tsx
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import React from "react";
-import { RecordingStatus } from "../../common/types";
+import { ActionContext, RecordingStatus } from "../../common/types";
 import { UrlContext } from "../../contexts/UrlContext";
 import {
   IRecordingContext,
@@ -72,11 +72,9 @@ describe("<HeaderControls />", () => {
       >
         <StepsContext.Provider
           value={{
-            steps: [],
-            setSteps: jest.fn(),
+            actions: [],
+            setActions: jest.fn(),
             onDeleteAction: jest.fn(),
-            onInsertAction: jest.fn(),
-            onStepDetailChange: jest.fn(),
             ...stepsCtxOverrides,
           }}
         >
@@ -117,7 +115,7 @@ describe("<HeaderControls />", () => {
         recordingStatus: RecordingStatus.Recording,
       },
       undefined,
-      { steps: [[]] }
+      { actions: [[]] }
     );
     const { getByText, getByLabelText } = render(comp);
 

--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -40,7 +40,7 @@ import { StartOverWarningModal } from "../StartOverWarningModal";
 import { TestButton } from "../TestButton";
 import { RecordingStatusIndicator } from "./StatusIndicator";
 
-interface IHeaderControls {
+export interface IHeaderControls {
   setIsCodeFlyoutVisible: Setter<boolean>;
 }
 

--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -126,7 +126,7 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
               <EuiButton
                 color="text"
                 iconType="editorCodeBlock"
-                onClick={async function () {
+                onClick={function () {
                   setIsCodeFlyoutVisible(true);
                 }}
               >

--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -28,81 +28,138 @@ import {
   EuiButton,
   useEuiTheme,
 } from "@elastic/eui";
-import React, { useContext } from "react";
+import React, { useCallback, useContext, useState } from "react";
 import { RecordingStatus, Setter } from "../../common/types";
 import { RecordingContext } from "../../contexts/RecordingContext";
+import { StepsContext } from "../../contexts/StepsContext";
 import { TestContext } from "../../contexts/TestContext";
+import { UrlContext } from "../../contexts/UrlContext";
 import { ControlButton } from "../ControlButton";
 import { SaveCodeButton } from "../ExportScriptButton";
+import { StartOverWarningModal } from "../StartOverWarningModal";
 import { TestButton } from "../TestButton";
 import { RecordingStatusIndicator } from "./StatusIndicator";
 
 interface IHeaderControls {
-  hasActions: boolean;
   setIsCodeFlyoutVisible: Setter<boolean>;
 }
 
-export function HeaderControls({
-  hasActions: disabled,
-  setIsCodeFlyoutVisible,
-}: IHeaderControls) {
+export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
   const { euiTheme } = useEuiTheme();
-  const { recordingStatus, toggleRecording } = useContext(RecordingContext);
+  const [isModalVisible, setIsModalVisible] = useState(false);
+
+  const { urlRef } = useContext(UrlContext);
+
+  const { abortSession, recordingStatus, togglePause, toggleRecording } =
+    useContext(RecordingContext);
+
+  const { actions: stepActions } = useContext(StepsContext);
+
   const { onTest } = useContext(TestContext);
+
+  const startOver = useCallback(async () => {
+    await abortSession();
+    setIsModalVisible(false);
+    if (urlRef) urlRef.current?.focus();
+  }, [abortSession, urlRef]);
+
   return (
-    <EuiFlexGroup
-      alignItems="center"
-      gutterSize="m"
-      style={{
-        backgroundColor: euiTheme.colors.lightestShade,
-        borderBottom: euiTheme.border.thin,
-        margin: "0px 0px 4px 0px",
-        padding: 8,
-      }}
-    >
-      <EuiFlexItem grow={false}>
-        <ControlButton
-          aria-label="Toggle script recording on/off"
-          color="primary"
-          iconType={
-            recordingStatus === RecordingStatus.Recording ? "stop" : "play"
-          }
-          onClick={toggleRecording}
-        >
-          {recordingStatus === RecordingStatus.Recording
-            ? "Stop"
-            : "Start recording"}
-        </ControlButton>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <RecordingStatusIndicator status={recordingStatus} />
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiFlexGroup gutterSize="m">
-          <EuiFlexItem>
-            <TestButton disabled={disabled} onTest={onTest} />
-          </EuiFlexItem>
-          <EuiFlexItem
-            style={{
-              borderRight: euiTheme.border.thin,
-              paddingRight: 16,
-            }}
+    <>
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="m"
+        style={{
+          backgroundColor: euiTheme.colors.lightestShade,
+          borderBottom: euiTheme.border.thin,
+          margin: "0px 0px 4px 0px",
+          padding: 8,
+        }}
+      >
+        <EuiFlexItem grow={false}>
+          <ControlButton
+            aria-label="Toggle the script recorder between recording and paused"
+            color="primary"
+            iconType={
+              recordingStatus === RecordingStatus.Recording ? "pause" : "play"
+            }
+            fill
+            onClick={
+              recordingStatus === RecordingStatus.NotRecording
+                ? toggleRecording
+                : togglePause
+            }
           >
-            <EuiButton
-              color="text"
-              iconType="editorCodeBlock"
-              onClick={async function () {
-                setIsCodeFlyoutVisible(true);
+            {getPlayControlCopy(recordingStatus)}
+          </ControlButton>
+        </EuiFlexItem>
+        {recordingStatus !== RecordingStatus.NotRecording && (
+          <EuiFlexItem grow={false}>
+            <ControlButton
+              aria-label="Stop recording and clear all recorded actions"
+              disabled={recordingStatus !== RecordingStatus.Recording}
+              color="primary"
+              iconType="refresh"
+              onClick={() => {
+                if (!isModalVisible) {
+                  setIsModalVisible(true);
+                }
               }}
             >
-              View code
-            </EuiButton>
+              Start over
+            </ControlButton>
           </EuiFlexItem>
-          <EuiFlexItem>
-            <SaveCodeButton />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlexItem>
-    </EuiFlexGroup>
+        )}
+        <EuiFlexItem>
+          <RecordingStatusIndicator status={recordingStatus} />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiFlexGroup gutterSize="m">
+            <EuiFlexItem>
+              <TestButton disabled={stepActions.length === 0} onTest={onTest} />
+            </EuiFlexItem>
+            <EuiFlexItem
+              style={{
+                borderRight: euiTheme.border.thin,
+                paddingRight: 16,
+              }}
+            >
+              <EuiButton
+                color="text"
+                iconType="editorCodeBlock"
+                onClick={async function () {
+                  setIsCodeFlyoutVisible(true);
+                }}
+              >
+                View code
+              </EuiButton>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <SaveCodeButton />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      {isModalVisible && (
+        <StartOverWarningModal
+          close={() => setIsModalVisible(false)}
+          startOver={startOver}
+          stepCount={stepActions.length}
+        />
+      )}
+    </>
   );
+}
+
+function getPlayControlCopy(status: RecordingStatus) {
+  switch (status) {
+    case RecordingStatus.NotRecording:
+      return "Start recording";
+    case RecordingStatus.Recording:
+      return "Pause";
+    case RecordingStatus.Paused:
+      return "Resume";
+    default:
+      return "";
+  }
 }

--- a/src/contexts/StepsContext.ts
+++ b/src/contexts/StepsContext.ts
@@ -29,7 +29,7 @@ function notImplemented() {
   throw Error("Step context not initialized");
 }
 
-interface IStepsContext {
+export interface IStepsContext {
   actions: ActionContext[][];
   onDeleteAction: (stepIndex: number, actionIndex: number) => void;
   setActions: Setter<ActionContext[][]>;

--- a/src/contexts/UrlContext.ts
+++ b/src/contexts/UrlContext.ts
@@ -1,0 +1,31 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import { createContext, MutableRefObject } from "react";
+
+interface IUrlContext {
+  urlRef?: MutableRefObject<HTMLInputElement | null>;
+}
+
+export const UrlContext = createContext<IUrlContext>({});


### PR DESCRIPTION
## Summary

Resolves #124.

The purpose of this PR is to prepare the recorder for release. The most notable reason, as noted in #124, is to unify the updated Play/Pause/Restart flow with the new header we recently merged.

We should also look for any glaring UX/export issues. The recorder is in a transitional UI state, but there is a lot of improved functionality we would like to release in the meantime until the UI re-vamp is complete.

## Implementation details

Most notable is the move from the original start/end buttons to the header.

## How to validate this change

Try starting/pausing/stopping journey recording to make sure the recorder is working.