### PR TITLE
Ignore `demo-app/package-lock.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ local-browsers
 .synthetics
 react-app-env.d.ts
 eslint-junit.xml
+demo-app/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ local-browsers
 .synthetics
 react-app-env.d.ts
 eslint-junit.xml
-demo-app/package-lock.json

--- a/demo-app/.gitignore
+++ b/demo-app/.gitignore
@@ -25,3 +25,5 @@ yarn-debug.log*
 yarn-error.log*
 
 .vercel
+
+package-lock.json

--- a/demo-app/.npmrc
+++ b/demo-app/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
## Summary

Purpose here is to ignore a `package-lock.json` if it's created on the demo app during an install run.

## Implementation details

Also, this added an empty line at the bottom of the `package.json`, I'm not sure if this will differ based on the dev platform.

## How to validate this change

Run `npm i` or `npm ci` and see if a `package-lock.json` shows up in the demo app directory.