### PR TITLE
chore: Ignore code formatting in `dist` dir

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 build
+dist
 local-browsers


### PR DESCRIPTION
## Summary

Prettier was complaining about the `dist` folder after I had done a production build.

We should ignore the formatting of files in that directory.

## Implementation details

N/A

## How to validate this change

Run `npm pack` and try to commit some files in a tracked location. The pre-commit hooks should fire, but they shouldn't block you from committing because of formatting errors within your `dist` folder.
