### PR TITLE
chore: Rename app id to correspond to the ID planned for notarization use

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "homepage": "./",
   "build": {
     "productName": "Elastic Synthetics Recorder",
-    "appId": "com.elastic.synthetics-recorder",
+    "appId": "co.elastic.synthetics-recorder",
     "files": [
       "build/**/*",
       "scripts/**/*",


### PR DESCRIPTION
Renames the app ID specified in the `package.json` to correspond to the ID we plan to use when notarizing the application for macOS.