### PR TITLE
feat: Disallow test run during recording session

### DIFF
--- a/e2e/tests/runTest.test.ts
+++ b/e2e/tests/runTest.test.ts
@@ -30,17 +30,18 @@ afterEach(async () => {
   await electronService.terminate();
 });
 
-describe("Steps", () => {
-  it("has the right number of step results", async () => {
+describe("Test Button", () => {
+  it("is disabled during a recording session", async () => {
     const electronWindow = await electronService.getWindow();
 
     await electronService.enterTestUrl(env.DEMO_APP_URL);
-
     await electronService.clickStartRecording();
     await electronService.waitForPageToBeIdle();
-    await electronService.clickStopRecording();
-    await electronService.clickRunTest();
 
-    expect(await electronWindow.$("text=1 success"));
+    const testButton = await electronWindow.$(
+      `[aria-label="You cannot test your recorded tests until you have finished a recording session"]`
+    );
+    expect(testButton).toBeTruthy();
+    expect(await testButton.isEnabled());
   });
 });

--- a/e2e/tests/runTest.test.ts
+++ b/e2e/tests/runTest.test.ts
@@ -39,7 +39,7 @@ describe("Test Button", () => {
     await electronService.waitForPageToBeIdle();
 
     const testButton = await electronWindow.$(
-      `[aria-label="You cannot test your recorded tests until you have finished a recording session"]`
+      `[aria-label="You cannot execute your recorded tests until you have finished a recording session"]`
     );
     expect(testButton).toBeTruthy();
     expect(await testButton.isEnabled());

--- a/src/components/TestButton.tsx
+++ b/src/components/TestButton.tsx
@@ -36,7 +36,7 @@ export function TestButton({ isDisabled, onTest }: Props) {
     <ControlButton
       aria-label={
         isDisabled
-          ? "Record a step in order to run a test"
+          ? "You cannot test your recorded tests until you have finished a recording session"
           : "Perform a test run for the journey you have recorded"
       }
       color="primary"

--- a/src/components/TestButton.tsx
+++ b/src/components/TestButton.tsx
@@ -36,7 +36,7 @@ export function TestButton({ isDisabled, onTest }: Props) {
     <ControlButton
       aria-label={
         isDisabled
-          ? "You cannot test your recorded tests until you have finished a recording session"
+          ? "You cannot execute your recorded tests until you have finished a recording session"
           : "Perform a test run for the journey you have recorded"
       }
       color="primary"


### PR DESCRIPTION
## Summary

Resolves #127.

Makes it so the user can't have the recorder run their script until they've finished recording.

## Implementation details

We've decided that it's a better experience if the user doesn't attempt to run their test until after they terminate their recording session.

## How to validate this change

1. Run the recorder
2. Start a recording session
3. Observe that the replay steps button is disabled
4. Close your Chromium recording session
5. Observe that you can now replay the steps you recorded