### PR TITLE
chore: Update dev docs to recommend checking node version before `npm install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Additionally, you can display the generated JavaScript code using the `Show scri
 
 ### Develop
 
+**Note:** the recorder is intended to be run against a specific version of `node`/`npm`.
+If you use `nvm` to manage your versions, you can simply run `nvm use` to switch to the
+appropriate version. If not, you can view the current supported version in the `.nvmrc` file.
+You can see potential error outputs as a result of using the incorrect version below in the troubleshooting section.
+
 Install the dependencies
 
 ```


### PR DESCRIPTION
## Summary

Currently the dev section of the project's README does not specify that the user check their `node` version before trying to `npm install`. This can set them up for unpleasant errors that they need to check the troubleshooting section below for.

In my opinion, it's reasonable to check this every time before attempting to do an install, so we should include a note at the start of the dev process that will ask the user to check that their current version is the one supported by the recorder. This can cut down on the number of bad experiences that people will have when they are attempting to run the recorder for the first time.

## Implementation details

Check for typos and bad writing style.

## How to validate this change

Ensure that the command(s) specified in the change look correct.