### PR TITLE
feat: Asynchronously report journey test result

### DIFF
--- a/electron/menu.js
+++ b/electron/menu.js
@@ -53,7 +53,11 @@ function buildMenu(appName) {
     },
     {
       label: "View",
-      submenu: [{ role: "reload" }, { role: "forcereload" }],
+      submenu: [
+        { role: "reload" },
+        { role: "forcereload" },
+        { role: "toggleDevTools" },
+      ],
     },
     {
       role: "window",

--- a/electron/menu.js
+++ b/electron/menu.js
@@ -53,11 +53,7 @@ function buildMenu(appName) {
     },
     {
       label: "View",
-      submenu: [
-        { role: "reload" },
-        { role: "forcereload" },
-        { role: "toggleDevTools" },
-      ],
+      submenu: [{ role: "reload" }, { role: "forcereload" }],
     },
     {
       role: "window",

--- a/src/common/shared.test.ts
+++ b/src/common/shared.test.ts
@@ -96,11 +96,11 @@ describe("shared", () => {
     let mockIpc: RendererProcessIpc;
 
     beforeEach(() => {
-      // @ts-expect-error partial implementation for testing
-      mockIpc = {
+      const mock = {
         answerMain: jest.fn(),
         callMain: jest.fn(),
       };
+      mockIpc = mock as unknown as RendererProcessIpc;
     });
 
     it("returns empty string for undefined journey", async () => {

--- a/src/common/shared.test.ts
+++ b/src/common/shared.test.ts
@@ -22,8 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { updateAction } from "./shared";
-import type { Steps } from "./types";
+import { RendererProcessIpc } from "electron-better-ipc";
+import { getCodeForFailedResult, updateAction } from "./shared";
+import type { Step, Steps } from "./types";
 
 describe("shared", () => {
   describe("updateAction", () => {
@@ -88,6 +89,81 @@ describe("shared", () => {
           action: { ...steps[0][2].action, value: "nextValue" },
         })
       );
+    });
+  });
+
+  describe("getCodeForFailedResult", () => {
+    let mockIpc: RendererProcessIpc;
+
+    beforeEach(() => {
+      // @ts-expect-error partial implementation for testing
+      mockIpc = {
+        answerMain: jest.fn(),
+        callMain: jest.fn(),
+      };
+    });
+
+    it("returns empty string for undefined journey", async () => {
+      expect(await getCodeForFailedResult(mockIpc, [])).toBe("");
+    });
+
+    it("returns an empty string if there are no failed steps in the journey", async () => {
+      expect(
+        await getCodeForFailedResult(mockIpc, [], {
+          status: "succeeded",
+          type: "inline",
+          steps: [
+            {
+              duration: 10,
+              name: "I succeeded",
+              status: "succeeded",
+            },
+          ],
+        })
+      ).toBe("");
+    });
+
+    it("returns an empty string if there is no step title matching journey name", async () => {
+      expect(
+        await getCodeForFailedResult(mockIpc, [], {
+          status: "failed",
+          type: "inline",
+          steps: [
+            {
+              duration: 10,
+              name: "I failed",
+              status: "failed",
+            },
+          ],
+        })
+      ).toBe("");
+    });
+
+    it("calls `getCodeFromActions` when a matching step for the failed journey step is found", async () => {
+      const failedStep: Step = [
+        {
+          title: "I failed",
+          action: {
+            name: "click",
+            signals: [],
+          },
+          isMainFrame: true,
+          frameUrl: "https://www.elastic.co",
+          pageAlias: "page alias",
+        },
+      ];
+
+      await getCodeForFailedResult(mockIpc, [failedStep], {
+        status: "failed",
+        type: "inline",
+        steps: [{ duration: 10, name: "I failed", status: "failed" }],
+      });
+
+      expect(mockIpc.callMain).toHaveBeenCalledTimes(1);
+      expect(mockIpc.callMain).toHaveBeenCalledWith("actions-to-code", {
+        actions: failedStep,
+        isSuite: false,
+      });
     });
   });
 });

--- a/src/common/shared.ts
+++ b/src/common/shared.ts
@@ -122,13 +122,21 @@ export function updateAction(
   });
 }
 
+/**
+ * Gets code string for failed step in result object.
+ * @param steps steps to analyze
+ * @param journey journey result data
+ * @returns code string
+ */
 export async function getCodeForResult(
   ipc: RendererProcessIpc,
   steps: ActionContext[][],
   journey: Journey | undefined
 ): Promise<string> {
   if (!journey) return "";
-  const journeyStepNames = new Set(journey.steps.map(({ name }) => name));
+  const journeyStepNames = new Set(
+    journey.steps.filter(s => s.status === "failed").map(({ name }) => name)
+  );
 
   return await getCodeFromActions(
     ipc,

--- a/src/common/shared.ts
+++ b/src/common/shared.ts
@@ -128,25 +128,24 @@ export function updateAction(
  * @param journey journey result data
  * @returns code string
  */
-export async function getCodeForResult(
+export async function getCodeForFailedResult(
   ipc: RendererProcessIpc,
   steps: ActionContext[][],
-  journey: Journey | undefined
+  journey?: Journey
 ): Promise<string> {
   if (!journey) return "";
-  const journeyStepNames = new Set(
-    journey.steps.filter(s => s.status === "failed").map(({ name }) => name)
+
+  const failedJourneyStep = journey.steps.find(
+    ({ status }) => status === "failed"
   );
 
-  return await getCodeFromActions(
-    ipc,
-    steps.filter(
-      step =>
-        step !== null &&
-        step.length > 0 &&
-        step[0].title &&
-        journeyStepNames.has(step[0].title)
-    ),
-    journey.type
+  if (typeof failedJourneyStep === "undefined") return "";
+
+  const failedStep = steps.find(
+    step => step.length > 0 && step[0].title === failedJourneyStep.name
   );
+
+  if (typeof failedStep === "undefined") return "";
+
+  return getCodeFromActions(ipc, [failedStep], journey.type);
 }

--- a/src/common/shared.ts
+++ b/src/common/shared.ts
@@ -139,13 +139,13 @@ export async function getCodeForFailedResult(
     ({ status }) => status === "failed"
   );
 
-  if (typeof failedJourneyStep === "undefined") return "";
+  if (!failedJourneyStep) return "";
 
   const failedStep = steps.find(
     step => step.length > 0 && step[0].title === failedJourneyStep.name
   );
 
-  if (typeof failedStep === "undefined") return "";
+  if (!failedStep) return "";
 
   return getCodeFromActions(ipc, [failedStep], journey.type);
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -62,7 +62,7 @@ export interface Result {
 }
 
 export interface Journey {
-  status: string; //TODO: define type? e.g. "create"
+  status: string;
   steps: Array<JourneyStep>;
   type: JourneyType;
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -67,13 +67,15 @@ export interface Journey {
   type: JourneyType;
 }
 
-export type ResultCategory = "succeeded" | "failed" | "skipped";
+export type StepStatus = "succeeded" | "failed" | "skipped";
+
+export type ResultCategory = StepStatus | "running";
 
 export interface JourneyStep {
   duration: number;
   error?: Error;
   name: string;
-  status: ResultCategory;
+  status: StepStatus;
 }
 
 export type JourneyType = "suite" | "inline";
@@ -107,4 +109,13 @@ export interface StepEndEvent {
   data: JourneyStep;
 }
 
-export type TestEvent = JourneyStartEvent | JourneyEndEvent | StepEndEvent;
+export interface ResultOverride {
+  event: "override";
+  data: Result | undefined;
+}
+
+export type TestEvent =
+  | JourneyStartEvent
+  | JourneyEndEvent
+  | StepEndEvent
+  | ResultOverride;

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -62,7 +62,7 @@ export interface Result {
 }
 
 export interface Journey {
-  status: string;
+  status: string; //TODO: define type? e.g. "create"
   steps: Array<JourneyStep>;
   type: JourneyType;
 }
@@ -87,3 +87,24 @@ export enum RecordingStatus {
   Recording = "RECORDING",
   Paused = "PAUSED",
 }
+
+export interface JourneyStartEvent {
+  event: "journey/start";
+  data: {
+    name: string;
+  };
+}
+
+export interface JourneyEndEvent {
+  event: "journey/end";
+  data: {
+    name: string;
+    status: "succeeded" | "failed"; // TBC
+  };
+}
+export interface StepEndEvent {
+  event: "step/end";
+  data: JourneyStep;
+}
+
+export type TestEvent = JourneyStartEvent | JourneyEndEvent | StepEndEvent;

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -101,7 +101,7 @@ export interface JourneyEndEvent {
   event: "journey/end";
   data: {
     name: string;
-    status: "succeeded" | "failed"; // TBC
+    status: "succeeded" | "failed";
   };
 }
 export interface StepEndEvent {

--- a/src/components/ActionStatusIndicator.tsx
+++ b/src/components/ActionStatusIndicator.tsx
@@ -74,6 +74,7 @@ function getColorForStatus(
   euiTheme: EuiThemeComputed,
   status?: ResultCategory
 ) {
+  if (!status) return euiTheme.colors.darkestShade;
   switch (status) {
     case "succeeded":
       return euiTheme.colors.success;

--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -63,12 +63,14 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
     isTestInProgress,
     onTest: startTest,
     setIsTestInProgress,
+    setResult,
   } = useContext(TestContext);
 
   const onTest = useCallback(() => {
+    setResult(undefined);
     setIsTestInProgress(true);
     startTest();
-  }, [setIsTestInProgress, startTest]);
+  }, [setIsTestInProgress, setResult, startTest]);
 
   return (
     <Header alignItems="center" gutterSize="m">

--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -88,6 +88,7 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
         <ControlButton
           aria-label="Toggle the script recorder between recording and paused"
           color="primary"
+          isDisabled={isTestInProgress}
           iconType={
             recordingStatus === RecordingStatus.Recording ? "pause" : "play"
           }

--- a/src/components/TestResult/ResultBody.tsx
+++ b/src/components/TestResult/ResultBody.tsx
@@ -24,13 +24,13 @@ THE SOFTWARE.
 
 import { EuiFlexItem, EuiText } from "@elastic/eui";
 import React from "react";
-import type { ResultCategory } from "../../common/types";
+import type { StepStatus } from "../../common/types";
 import { ResultContentWithoutAccordion, symbols } from "./styles";
 
 interface IResultBody {
   durationElement: JSX.Element;
   name: string;
-  resultCategory: ResultCategory;
+  resultCategory: StepStatus;
 }
 
 export function ResultBody({

--- a/src/components/TestResult/ResultErrorBody.tsx
+++ b/src/components/TestResult/ResultErrorBody.tsx
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 import { EuiFlexGroup, EuiFlexItem, EuiText, EuiCodeBlock } from "@elastic/eui";
 import React from "react";
-import { ResultCategory } from "../../common/types";
+import type { StepStatus } from "../../common/types";
 import { ResultErrorAccordion, symbols } from "./styles";
 
 function removeColorCodes(str = "") {
@@ -37,7 +37,7 @@ export interface IResultErrorBody {
   durationElement: JSX.Element;
   errorMessage?: string;
   name: string;
-  resultCategory: ResultCategory;
+  resultCategory: StepStatus;
   stepIndex: number;
   stepName: string;
 }

--- a/src/components/TestResult/styles.tsx
+++ b/src/components/TestResult/styles.tsx
@@ -31,7 +31,7 @@ import {
 } from "@elastic/eui";
 import React from "react";
 import styled from "styled-components";
-import type { ResultCategory } from "../../common/types";
+import type { StepStatus } from "../../common/types";
 
 export const ResultContainer = styled(EuiPanel)`
   && {
@@ -58,7 +58,7 @@ export const Bold = styled(EuiText)`
   font-weight: 500;
 `;
 
-export const symbols: Record<ResultCategory, JSX.Element> = {
+export const symbols: Record<StepStatus, JSX.Element> = {
   succeeded: <EuiIcon color="success" type="check" />,
   failed: <EuiIcon color="danger" type="cross" />,
   skipped: <EuiIcon color="warning" type="flag" />,

--- a/src/contexts/TestContext.ts
+++ b/src/contexts/TestContext.ts
@@ -32,7 +32,7 @@ async function notImplementedAsync() {
   notImplemented();
 }
 
-interface ITestContext {
+export interface ITestContext {
   codeBlocks: string;
   isResultFlyoutVisible: boolean;
   isTestInProgress: boolean;
@@ -40,8 +40,8 @@ interface ITestContext {
   result?: Result;
   setIsTestInProgress: Setter<boolean>;
   setCodeBlocks: Setter<string>;
-  setResult: Setter<Result | undefined>;
   setIsResultFlyoutVisible: Setter<boolean>;
+  setResult: (data: Result | undefined) => void;
 }
 
 export const TestContext = createContext<ITestContext>({

--- a/src/helpers/resultReducer.test.ts
+++ b/src/helpers/resultReducer.test.ts
@@ -1,0 +1,235 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import { resultReducer } from "./resultReducer";
+
+describe("result reducer", () => {
+  it.each(["inline", "suite"])("initializes result on journey start", type => {
+    expect(
+      resultReducer(undefined, {
+        event: "journey/start",
+        data: { name: type },
+      })
+    ).toEqual({
+      failed: 0,
+      skipped: 0,
+      succeeded: 0,
+      journey: {
+        status: "running",
+        type: type,
+        steps: [],
+      },
+    });
+  });
+
+  it("adds success step to result", () => {
+    expect(
+      resultReducer(undefined, {
+        event: "step/end",
+        data: {
+          name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+          status: "succeeded",
+          duration: 491,
+        },
+      })
+    ).toEqual({
+      failed: 0,
+      skipped: 0,
+      succeeded: 1,
+      journey: {
+        status: "running",
+        type: "inline",
+        steps: [
+          {
+            duration: 491,
+            name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+            status: "succeeded",
+          },
+        ],
+      },
+    });
+  });
+
+  it("adds failed step to result", () => {
+    expect(
+      resultReducer(undefined, {
+        event: "step/end",
+        data: {
+          name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+          status: "failed",
+          duration: 9000,
+        },
+      })
+    ).toEqual({
+      failed: 1,
+      skipped: 0,
+      succeeded: 0,
+      journey: {
+        status: "running",
+        type: "inline",
+        steps: [
+          {
+            duration: 9000,
+            name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+            status: "failed",
+          },
+        ],
+      },
+    });
+  });
+
+  it("adds skipped step to result", () => {
+    expect(
+      resultReducer(undefined, {
+        event: "step/end",
+        data: {
+          name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+          status: "skipped",
+          duration: 0,
+        },
+      })
+    ).toEqual({
+      failed: 0,
+      skipped: 1,
+      succeeded: 0,
+      journey: {
+        status: "running",
+        type: "inline",
+        steps: [
+          {
+            duration: 0,
+            name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+            status: "skipped",
+          },
+        ],
+      },
+    });
+  });
+
+  it("updates the result to the final state from journey/end", () => {
+    expect(
+      resultReducer(
+        {
+          failed: 0,
+          skipped: 0,
+          succeeded: 1,
+          journey: {
+            status: "running",
+            type: "inline",
+            steps: [
+              {
+                duration: 100,
+                name: "Go to https://www.elastic.co",
+                status: "succeeded",
+              },
+            ],
+          },
+        },
+        {
+          event: "journey/end",
+          data: { name: "inline", status: "succeeded" },
+        }
+      )
+    );
+  });
+
+  it("constructs expected result for multiple calls", () => {
+    const a = resultReducer(undefined, {
+      event: "journey/start",
+      data: { name: "inline" },
+    });
+    const b = resultReducer(a, {
+      event: "step/end",
+      data: {
+        name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+        status: "succeeded",
+        duration: 491,
+      },
+    });
+    const c = resultReducer(b, {
+      event: "step/end",
+      data: {
+        name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+        status: "failed",
+        duration: 9000,
+      },
+    });
+    const d = resultReducer(c, {
+      event: "step/end",
+      data: {
+        name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+        status: "skipped",
+        duration: 0,
+      },
+    });
+    const e = resultReducer(d, {
+      event: "journey/end",
+      data: { name: "inline", status: "failed" },
+    });
+    expect(e).toEqual({
+      failed: 1,
+      skipped: 1,
+      succeeded: 1,
+      journey: {
+        status: "failed",
+        type: "inline",
+        steps: [
+          {
+            name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+            status: "succeeded",
+            duration: 491,
+          },
+          {
+            name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+            status: "failed",
+            duration: 9000,
+          },
+          {
+            duration: 0,
+            name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+            status: "skipped",
+          },
+        ],
+      },
+    });
+  });
+
+  it("handles override actions", () => {
+    expect(
+      resultReducer(
+        {
+          failed: 1,
+          skipped: 1,
+          succeeded: 1,
+          journey: {
+            status: "failed",
+            type: "inline",
+            steps: [],
+          },
+        },
+        { event: "override", data: undefined }
+      )
+    ).toBeUndefined();
+  });
+});

--- a/src/helpers/resultReducer.test.ts
+++ b/src/helpers/resultReducer.test.ts
@@ -151,7 +151,22 @@ describe("result reducer", () => {
           data: { name: "inline", status: "succeeded" },
         }
       )
-    );
+    ).toEqual({
+      failed: 0,
+      skipped: 0,
+      succeeded: 1,
+      journey: {
+        status: "succeeded",
+        steps: [
+          {
+            duration: 100,
+            name: "Go to https://www.elastic.co",
+            status: "succeeded",
+          },
+        ],
+        type: "inline",
+      },
+    });
   });
 
   it("constructs expected result for multiple calls", () => {

--- a/src/helpers/resultReducer.ts
+++ b/src/helpers/resultReducer.ts
@@ -75,7 +75,5 @@ export function resultReducer(
     case "override": {
       return action.data;
     }
-    default:
-      return state;
   }
 }

--- a/src/helpers/resultReducer.ts
+++ b/src/helpers/resultReducer.ts
@@ -1,0 +1,81 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import type { JourneyType, TestEvent, Result } from "../common/types";
+
+const initJourney = (type = "inline") => ({
+  failed: 0,
+  skipped: 0,
+  succeeded: 0,
+  journey: {
+    status: "running",
+    type: type as JourneyType,
+    steps: [],
+  },
+});
+
+/**
+ * Use this function to incrementally build the result object for a test result
+ * as the chunks are streamed from the backend.
+ * @param state current result data
+ * @param action update action
+ * @returns new state
+ */
+export function resultReducer(
+  state: Result | undefined,
+  action: TestEvent
+): Result | undefined {
+  if (action.event === "journey/start") {
+    return initJourney(action.data.name);
+  }
+  const nextResult = typeof state === "undefined" ? initJourney() : state;
+  switch (action.event) {
+    case "step/end": {
+      nextResult[action.data.status]++;
+      const steps = [...nextResult.journey.steps, { ...action.data }];
+      const journey = {
+        ...nextResult.journey,
+        steps,
+      };
+      return {
+        ...nextResult,
+        journey,
+      };
+    }
+    case "journey/end": {
+      return {
+        ...nextResult,
+        journey: {
+          ...nextResult.journey,
+          status: action.data.status,
+        },
+      };
+    }
+    case "override": {
+      return action.data;
+    }
+    default:
+      return state;
+  }
+}

--- a/src/hooks/useSyntheticsTest.ts
+++ b/src/hooks/useSyntheticsTest.ts
@@ -34,7 +34,6 @@ import { getCodeFromActions, getCodeForFailedResult } from "../common/shared";
 import { Result, Steps, TestEvent } from "../common/types";
 import { ITestContext } from "../contexts/TestContext";
 import { CommunicationContext } from "../contexts/CommunicationContext";
-import logger from "electron-log";
 import { resultReducer } from "../helpers/resultReducer";
 
 export function useSyntheticsTest(steps: Steps): ITestContext {
@@ -65,7 +64,8 @@ export function useSyntheticsTest(steps: Steps): ITestContext {
           setIsResultFlyoutVisible(true);
           await promise;
         } catch (e: unknown) {
-          logger.error(e);
+          // eslint-disable-next-line no-console
+          console.error(e);
         } finally {
           ipc.removeListener("test-event", onTestEvent);
           setIsTestInProgress(false);

--- a/src/hooks/useSyntheticsTest.ts
+++ b/src/hooks/useSyntheticsTest.ts
@@ -23,6 +23,7 @@ THE SOFTWARE.
 */
 
 import { useCallback, useContext, useEffect, useState } from "react";
+import { IpcRendererEvent } from "electron";
 import { getCodeForResult, getCodeFromActions } from "../common/shared";
 import { CommunicationContext } from "../contexts/CommunicationContext";
 import { Result, Steps, TestEvent } from "../common/types";
@@ -44,8 +45,9 @@ export function useSyntheticsTest(steps: Steps) {
     }
   }, [steps.length, result]);
 
-  const onTestEvent = (ev: TestEvent) => {
-    console.log(ev);
+  const onTestEvent = (_event: IpcRendererEvent, data: TestEvent) => {
+    //TODO: display the data
+    console.log(data);
   };
   const onTest = useCallback(
     async function () {

--- a/src/hooks/useSyntheticsTest.ts
+++ b/src/hooks/useSyntheticsTest.ts
@@ -30,7 +30,7 @@ import {
   useReducer,
   useState,
 } from "react";
-import { getCodeForResult, getCodeFromActions } from "../common/shared";
+import { getCodeFromActions, getCodeForFailedResult } from "../common/shared";
 import { Result, Steps, TestEvent } from "../common/types";
 import { ITestContext } from "../contexts/TestContext";
 import { CommunicationContext } from "../contexts/CommunicationContext";
@@ -74,9 +74,11 @@ export function useSyntheticsTest(steps: Steps): ITestContext {
   );
 
   useEffect(() => {
-    getCodeForResult(ipc, steps, result?.journey).then(code =>
-      setCodeBlocks(code)
-    );
+    if (result?.journey.status === "failed") {
+      getCodeForFailedResult(ipc, steps, result?.journey).then(code =>
+        setCodeBlocks(code)
+      );
+    }
   }, [ipc, result?.journey, steps]);
 
   /**

--- a/src/hooks/useSyntheticsTest.ts
+++ b/src/hooks/useSyntheticsTest.ts
@@ -25,7 +25,7 @@ THE SOFTWARE.
 import { useCallback, useContext, useEffect, useState } from "react";
 import { getCodeForResult, getCodeFromActions } from "../common/shared";
 import { CommunicationContext } from "../contexts/CommunicationContext";
-import { Result, Steps } from "../common/types";
+import { Result, Steps, TestEvent } from "../common/types";
 
 export function useSyntheticsTest(steps: Steps) {
   const [result, setResult] = useState<Result | undefined>(undefined);
@@ -44,12 +44,16 @@ export function useSyntheticsTest(steps: Steps) {
     }
   }, [steps.length, result]);
 
+  const onTestEvent = (ev: TestEvent) => {
+    console.log(ev);
+  };
   const onTest = useCallback(
     async function () {
       /**
        * For the time being we are only running tests as inline.
        */
       const code = await getCodeFromActions(ipc, steps, "inline");
+      ipc.on("test-event", onTestEvent);
       const resultFromServer: Result = await ipc.callMain("run-journey", {
         code,
         isSuite: false,
@@ -59,6 +63,7 @@ export function useSyntheticsTest(steps: Steps) {
       setResult(resultFromServer);
       setIsResultFlyoutVisible(true);
       setIsTestInProgress(false);
+      ipc.removeListener("test-event", onTestEvent);
     },
     [steps, ipc, result]
   );

--- a/src/hooks/useSyntheticsTest.ts
+++ b/src/hooks/useSyntheticsTest.ts
@@ -47,6 +47,8 @@ export function useSyntheticsTest(steps: Steps): ITestContext {
     async function () {
       const code = await getCodeFromActions(ipc, steps, "inline");
       if (!isTestInProgress) {
+        // destroy stale state
+        dispatch({ data: undefined, event: "override" });
         const onTestEvent = (_event: IpcRendererEvent, data: TestEvent) => {
           dispatch(data);
         };

--- a/src/hooks/useSyntheticsTest.ts
+++ b/src/hooks/useSyntheticsTest.ts
@@ -34,6 +34,7 @@ import { getCodeFromActions, getCodeForFailedResult } from "../common/shared";
 import { Result, Steps, TestEvent } from "../common/types";
 import { ITestContext } from "../contexts/TestContext";
 import { CommunicationContext } from "../contexts/CommunicationContext";
+import logger from "electron-log";
 import { resultReducer } from "../helpers/resultReducer";
 
 export function useSyntheticsTest(steps: Steps): ITestContext {
@@ -64,8 +65,7 @@ export function useSyntheticsTest(steps: Steps): ITestContext {
           setIsResultFlyoutVisible(true);
           await promise;
         } catch (e: unknown) {
-          // eslint-disable-next-line no-console
-          console.error(e);
+          logger.error(e);
         } finally {
           ipc.removeListener("test-event", onTestEvent);
           setIsTestInProgress(false);


### PR DESCRIPTION
<!-- Thanks for your pull request. Please fill all of the mandatory fields in this template. That will help us get back to you sooner. -->

<!-- If it's your first time contributing to an Elastic repo, don't forget to sign our CLA at https://www.elastic.co/contributor-agreement -->


## Summary

<!-- What does this change do? Which issue does it solve? -->
part of #61 
When replaying the script, the test result is returned to the frontend after reaching the end of the journey(either success or fail). We'd like to see progressive feedback when each step is finished.

<!-- If you have any screenshots or GIFs, here's where you should include them. -->


## Implementation details
<!-- If you're solving a bug, what caused it, and how did you fix it? -->

<!-- If you're adding a feature or implementing an enhancement, what are notable aspects about its implementation? -->
When the output is returned from the Synthetics CLI, Electron parses the output and constructs event object and then sends it via `webContents.send()`. The available event types are `journey/start`, `journey/end`, and `step/end` at the moment. The frontend subscribes to the event emitter and displays relevant result information whenever available. 

## How to validate this change
click the Replay Steps button to start the test, observe the application showing feedback after each step while the test is still executed in the browser.
<!-- How can others validate that what you've done is correct? -->

<!-- Is there any particular subject on which you need more input? -->
