### PR TITLE
chore: Remove direct `ipc` imports, centralize import with `CommunicationContext`

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import React from "react";
+import React, { useContext } from "react";
 import { useEffect, useRef, useState } from "react";
 import { EuiFlexGroup, EuiFlexItem, EuiPageBody } from "@elastic/eui";
 import "./App.css";
@@ -34,6 +34,7 @@ import { AssertionDrawer } from "./components/AssertionDrawer";
 import { Title } from "./components/Header/Title";
 import { HeaderControls } from "./components/Header/HeaderControls";
 import { AssertionContext } from "./contexts/AssertionContext";
+import { CommunicationContext } from "./contexts/CommunicationContext";
 import { RecordingContext } from "./contexts/RecordingContext";
 import { StepsContext } from "./contexts/StepsContext";
 import { TestContext } from "./contexts/TestContext";
@@ -43,8 +44,6 @@ import { useAssertionDrawer } from "./hooks/useAssertionDrawer";
 import { useSyntheticsTest } from "./hooks/useSyntheticsTest";
 import { generateIR, generateMergedIR } from "./helpers/generator";
 import { UrlContext } from "./contexts/UrlContext";
-
-const { ipcRenderer: ipc } = window.require("electron-better-ipc");
 
 const MAIN_CONTROLS_MIN_WIDTH = 600;
 
@@ -56,6 +55,7 @@ export default function App() {
   );
   const [isCodeFlyoutVisible, setIsCodeFlyoutVisible] = useState(false);
 
+  const { ipc } = useContext(CommunicationContext);
   const assertionDrawerUtils = useAssertionDrawer();
   const syntheticsTestUtils = useSyntheticsTest(stepActions);
 
@@ -72,7 +72,7 @@ export default function App() {
         return generateMergedIR(prevActionContexts, currActionsContexts);
       });
     });
-  }, [setStepActions]);
+  }, [setStepActions, ipc]);
 
   return (
     <div>

--- a/src/common/shared.ts
+++ b/src/common/shared.ts
@@ -22,10 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+import { RendererProcessIpc } from "electron-better-ipc";
 import React from "react";
 import type { ActionContext, Journey, JourneyType, Setter } from "./types";
-
-const { ipcRenderer: ipc } = window.require("electron-better-ipc");
 
 export const COMMAND_SELECTOR_OPTIONS = [
   {
@@ -68,11 +67,12 @@ export const SYNTHETICS_DISCUSS_FORUM_URL =
 export const SMALL_SCREEN_BREAKPOINT = 850;
 
 export function performSelectorLookup(
+  ipc: RendererProcessIpc,
   onSelectorChange: Setter<string | undefined>
 ) {
   return async () => {
     const selector = await ipc.callMain("set-mode", "inspecting");
-    if (selector) {
+    if (typeof selector === "string" && selector.length) {
       onSelectorChange(selector);
       await ipc.callMain("set-mode", "recording");
     }
@@ -80,9 +80,10 @@ export function performSelectorLookup(
 }
 
 export async function getCodeFromActions(
+  ipc: RendererProcessIpc,
   actions: ActionContext[][],
   type: JourneyType
-) {
+): Promise<string> {
   return await ipc.callMain("actions-to-code", {
     actions: actions.flat(),
     isSuite: type === "suite",
@@ -90,6 +91,7 @@ export async function getCodeFromActions(
 }
 
 export function createExternalLinkHandler(
+  ipc: RendererProcessIpc,
   url: string
 ): React.MouseEventHandler<HTMLAnchorElement> {
   return async e => {
@@ -115,6 +117,7 @@ export function updateAction(
 }
 
 export async function getCodeForResult(
+  ipc: RendererProcessIpc,
   steps: ActionContext[][],
   journey: Journey | undefined
 ): Promise<string> {
@@ -122,6 +125,7 @@ export async function getCodeForResult(
   const journeyStepNames = new Set(journey.steps.map(({ name }) => name));
 
   return await getCodeFromActions(
+    ipc,
     steps.filter(
       step =>
         step !== null &&

--- a/src/components/AssertionDrawer.tsx
+++ b/src/components/AssertionDrawer.tsx
@@ -48,6 +48,7 @@ import {
 import { StepsContext } from "../contexts/StepsContext";
 import { AssertionContext } from "../contexts/AssertionContext";
 import type { ActionContext } from "../common/types";
+import { CommunicationContext } from "../contexts/CommunicationContext";
 
 const PLAYWRIGHT_ASSERTIONS_DOCS_LINK =
   "https://playwright.dev/docs/assertions/";
@@ -81,6 +82,7 @@ const textFieldAssertionValues = ["innerText", "textContent"];
 
 export function AssertionDrawer() {
   const { actions, setActions } = useContext(StepsContext);
+  const { ipc } = useContext(CommunicationContext);
   const {
     actionIndex,
     action,
@@ -185,6 +187,7 @@ export function AssertionDrawer() {
                     iconSide="right"
                     iconType="popout"
                     onClick={createExternalLinkHandler(
+                      ipc,
                       PLAYWRIGHT_ASSERTIONS_DOCS_LINK
                     )}
                     size="xs"
@@ -210,7 +213,7 @@ export function AssertionDrawer() {
                     <EuiButtonIcon
                       aria-label="Choose the type of assertion command"
                       iconType="search"
-                      onClick={performSelectorLookup(setSelector)}
+                      onClick={performSelectorLookup(ipc, setSelector)}
                     />
                   }
                   onChange={e => setSelector(e.target.value)}

--- a/src/components/Header/Title.tsx
+++ b/src/components/Header/Title.tsx
@@ -31,13 +31,15 @@ import {
   EuiPageHeader,
   useEuiTheme,
 } from "@elastic/eui";
-import React from "react";
+import React, { useContext } from "react";
 import {
   createExternalLinkHandler,
   SYNTHETICS_DISCUSS_FORUM_URL,
 } from "../../common/shared";
+import { CommunicationContext } from "../../contexts/CommunicationContext";
 
 export function Title() {
+  const { ipc } = useContext(CommunicationContext);
   const { euiTheme } = useEuiTheme();
   return (
     <EuiPageHeader
@@ -76,7 +78,10 @@ export function Title() {
             iconSide="left"
             iconType="popout"
             key="link-to-synthetics-help"
-            onClick={createExternalLinkHandler(SYNTHETICS_DISCUSS_FORUM_URL)}
+            onClick={createExternalLinkHandler(
+              ipc,
+              SYNTHETICS_DISCUSS_FORUM_URL
+            )}
           >
             Send feedback
           </EuiButtonEmpty>

--- a/src/components/StepsMonitor.tsx
+++ b/src/components/StepsMonitor.tsx
@@ -38,6 +38,7 @@ import { getCodeFromActions } from "../common/shared";
 import { Steps } from "./Steps";
 import { StepsContext } from "../contexts/StepsContext";
 import type { ActionContext, JourneyType, Setter } from "../common/types";
+import { CommunicationContext } from "../contexts/CommunicationContext";
 
 interface IRecordedCodeTabs {
   selectedTab: JourneyType;
@@ -93,13 +94,14 @@ function CodeFlyout({
   setCode,
   setIsFlyoutVisible,
 }: ICodeFlyout) {
+  const { ipc } = useContext(CommunicationContext);
   const [type, setType] = useState<JourneyType>("inline");
   useEffect(() => {
     (async function getCode() {
-      const codeFromActions = await getCodeFromActions(actions, type);
+      const codeFromActions = await getCodeFromActions(ipc, actions, type);
       setCode(codeFromActions);
     })();
-  }, [actions, setCode, type]);
+  }, [actions, setCode, type, ipc]);
 
   return (
     <EuiFlyout

--- a/src/contexts/CommunicationContext.ts
+++ b/src/contexts/CommunicationContext.ts
@@ -22,22 +22,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { EuiButton } from "@elastic/eui";
-import React, { useContext } from "react";
-import { getCodeFromActions } from "../common/shared";
-import { CommunicationContext } from "../contexts/CommunicationContext";
-import { StepsContext } from "../contexts/StepsContext";
+import { RendererProcessIpc } from "electron-better-ipc";
+import { createContext } from "react";
 
-export function SaveCodeButton() {
-  const { actions } = useContext(StepsContext);
-  const { ipc } = useContext(CommunicationContext);
-  const onSave = async () => {
-    const codeFromActions = await getCodeFromActions(ipc, actions, "inline");
-    await ipc.callMain("save-file", codeFromActions);
-  };
-  return (
-    <EuiButton fill color="primary" iconType="exportAction" onClick={onSave}>
-      Export script
-    </EuiButton>
-  );
+const { ipcRenderer } = window.require("electron-better-ipc");
+
+export interface ICommunicationContext {
+  ipc: RendererProcessIpc;
 }
+
+export const CommunicationContext = createContext<ICommunicationContext>({
+  ipc: ipcRenderer,
+});

--- a/src/hooks/useSyntheticsTest.ts
+++ b/src/hooks/useSyntheticsTest.ts
@@ -22,31 +22,31 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { useCallback, useState } from "react";
+import { useCallback, useContext, useState } from "react";
 import { getCodeForResult, getCodeFromActions } from "../common/shared";
 import { ActionContext, Result } from "../common/types";
-
-const { ipcRenderer: ipc } = window.require("electron-better-ipc");
+import { CommunicationContext } from "../contexts/CommunicationContext";
 
 export function useSyntheticsTest(actions: ActionContext[][]) {
   const [result, setResult] = useState<Result | undefined>(undefined);
   const [codeBlocks, setCodeBlocks] = useState("");
+  const { ipc } = useContext(CommunicationContext);
 
   const onTest = useCallback(
     async function () {
       /**
        * For the time being we are only running tests as inline.
        */
-      const code = await getCodeFromActions(actions, "inline");
+      const code = await getCodeFromActions(ipc, actions, "inline");
       const resultFromServer: Result = await ipc.callMain("run-journey", {
         code,
         isSuite: false,
       });
 
-      setCodeBlocks(await getCodeForResult(actions, result?.journey));
+      setCodeBlocks(await getCodeForResult(ipc, actions, result?.journey));
       setResult(resultFromServer);
     },
-    [actions, result]
+    [actions, ipc, result]
   );
   return {
     codeBlocks,


### PR DESCRIPTION
## Summary

Resolves #142

## Implementation details

Per the linked issue, we have numerous imports of `electron-better-ipc` via `window.require`, which works fine in production but makes the code excruciating to test. Rather than introduce strange testing patterns throughout the codebase, I propose we use this `CommunicationContext`, which uses `window.require` as a single point of entry for `ipc`. 

We can then share this reference throughout the application, and modify any functions that were performing a direct import to use dependency injection instead. This will allow us to supply mocks very easily for any component or helper function that previously performed the import internally.

## How to validate this change

Run the recorder, record some steps, view exported code, run test and see the results. All of these activities will ensure that the IPC is still working ok.