### PR TITLE
chore: add watch script for unit test DX, ignore `coverage` dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+coverage
 dist
 build
 node_modules

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prepare": "husky install",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "jest --config ./jest.unit.config.js ./src",
+    "test:unit:watch": "jest --config ./jest.unit.config.js ./src --coverage --watch",
     "test:e2e": "jest --config ./jest.e2e.config.js ./e2e/tests",
     "test:e2e:server": "BROWSER=NONE PORT=61337 react-scripts start",
     "test:e2e:runner": "IS_RUNNER=true TEST_PORT=61337 jest --config ./jest.e2e.config.js ./e2e/tests",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prepare": "husky install",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "jest --config ./jest.unit.config.js ./src",
-    "test:unit:watch": "jest --config ./jest.unit.config.js ./src --coverage --watch",
+    "test:unit:watch": "npm run test:unit -- --coverage --watch",
     "test:e2e": "jest --config ./jest.e2e.config.js ./e2e/tests",
     "test:e2e:server": "BROWSER=NONE PORT=61337 react-scripts start",
     "test:e2e:runner": "IS_RUNNER=true TEST_PORT=61337 jest --config ./jest.e2e.config.js ./e2e/tests",


### PR DESCRIPTION
## Summary

Adds a `--watch` option for the npm test script with coverage flag set to aid with the unit test developer experience.

## Implementation details

Run `npm run test:unit:watch` to start `jest` in watch mode. `--coverage` flag is also set to generate coverage report for checking code paths within functions.

## How to validate this change

No user impact.