### PR TITLE
chore: Implement RTL helper to reduce test boilerplate

### DIFF
--- a/src/helpers/test/RenderContexts.tsx
+++ b/src/helpers/test/RenderContexts.tsx
@@ -1,0 +1,62 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import React from "react";
+
+export interface ContextRenderer<ContextValue> {
+  defaults: ContextValue;
+  Context: React.Context<ContextValue>;
+  overrides?: Partial<ContextValue>;
+}
+
+/**
+ * Takes a list of React Contexts and values and recursively renders them overtop of a given component.
+ * @returns Rendered contexts wrapping child component.
+ */
+export const RenderContexts = ({
+  contexts,
+  children,
+}: {
+  /* The below line circumvents TS screaming about the different context types not being
+   * compatible with a union of all types, i.e. "IRecordingContext is incompatible with IRecordingContext | IStepsContext".
+   *
+   * Given the purpose of this function is to recursively render a generic list of contexts, it's not
+   * imperative to know or care what the type of the context is.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  contexts: Array<ContextRenderer<any>>;
+  children?: React.ReactNode;
+}) => {
+  const context = contexts.shift();
+  if (typeof context === "undefined") {
+    return <>{children}</>;
+  }
+  const { defaults, Context, overrides } = context;
+  const value = overrides ? { ...defaults, ...overrides } : defaults;
+  return (
+    <Context.Provider value={value}>
+      <RenderContexts contexts={contexts}>{children}</RenderContexts>
+    </Context.Provider>
+  );
+};

--- a/src/helpers/test/defaults.ts
+++ b/src/helpers/test/defaults.ts
@@ -22,10 +22,28 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { createContext, MutableRefObject } from "react";
+import { RecordingStatus } from "../../common/types";
+import { IRecordingContext } from "../../contexts/RecordingContext";
+import { IStepsContext } from "../../contexts/StepsContext";
+import { IUrlContext } from "../../contexts/UrlContext";
 
-export interface IUrlContext {
-  urlRef?: MutableRefObject<HTMLInputElement | null>;
-}
+export const RECORDING_CONTEXT_DEFAULTS: IRecordingContext = {
+  isStartOverModalVisible: false,
+  setIsStartOverModalVisible: jest.fn(),
+  recordingStatus: RecordingStatus.NotRecording,
+  startOver: jest.fn(),
+  togglePause: jest.fn(),
+  toggleRecording: jest.fn(),
+};
 
-export const UrlContext = createContext<IUrlContext>({});
+export const URL_CONTEXT_DEFAULTS: IUrlContext = {};
+
+export const STEPS_CONTEXT_DEFAULTS: IStepsContext = {
+  steps: [],
+  setSteps: jest.fn(),
+  onDeleteAction: jest.fn(),
+  onInsertAction: jest.fn(),
+  onStepDetailChange: jest.fn(),
+  onDeleteStep: jest.fn(),
+  onUpdateAction: jest.fn(),
+};

--- a/src/helpers/test/index.ts
+++ b/src/helpers/test/index.ts
@@ -22,10 +22,4 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { createContext, MutableRefObject } from "react";
-
-export interface IUrlContext {
-  urlRef?: MutableRefObject<HTMLInputElement | null>;
-}
-
-export const UrlContext = createContext<IUrlContext>({});
+export { render } from "./render";

--- a/src/helpers/test/render.tsx
+++ b/src/helpers/test/render.tsx
@@ -22,7 +22,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { render as rtlRender, RenderResult } from "@testing-library/react";
+import {
+  render as rtlRender,
+  RenderResult,
+  RenderOptions,
+} from "@testing-library/react";
 import React from "react";
 import {
   IRecordingContext,
@@ -39,6 +43,7 @@ import { RenderContexts } from "./RenderContexts";
 
 export function render<ComponentType>(
   component: React.ReactElement<ComponentType>,
+  rtlRenderOptions?: Omit<RenderOptions, "queries">,
   options?: {
     contextOverrides?: {
       recording?: Partial<IRecordingContext>;
@@ -66,6 +71,7 @@ export function render<ComponentType>(
   ];
 
   return rtlRender(
-    <RenderContexts contexts={contexts}>{component}</RenderContexts>
+    <RenderContexts contexts={contexts}>{component}</RenderContexts>,
+    rtlRenderOptions
   );
 }

--- a/src/helpers/test/render.tsx
+++ b/src/helpers/test/render.tsx
@@ -1,0 +1,71 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import { render as rtlRender, RenderResult } from "@testing-library/react";
+import React from "react";
+import {
+  IRecordingContext,
+  RecordingContext,
+} from "../../contexts/RecordingContext";
+import { IStepsContext, StepsContext } from "../../contexts/StepsContext";
+import { IUrlContext, UrlContext } from "../../contexts/UrlContext";
+import {
+  RECORDING_CONTEXT_DEFAULTS,
+  URL_CONTEXT_DEFAULTS,
+  STEPS_CONTEXT_DEFAULTS,
+} from "./defaults";
+import { RenderContexts } from "./RenderContexts";
+
+export function render<ComponentType>(
+  component: React.ReactElement<ComponentType>,
+  options?: {
+    contextOverrides?: {
+      recording?: Partial<IRecordingContext>;
+      steps?: Partial<IStepsContext>;
+      url?: Partial<IUrlContext>;
+    };
+  }
+): RenderResult {
+  const contexts = [
+    {
+      defaults: RECORDING_CONTEXT_DEFAULTS,
+      Context: RecordingContext,
+      overrides: options?.contextOverrides?.recording,
+    },
+    {
+      defaults: URL_CONTEXT_DEFAULTS,
+      Context: UrlContext,
+      overrides: options?.contextOverrides?.url,
+    },
+    {
+      defaults: STEPS_CONTEXT_DEFAULTS,
+      Context: StepsContext,
+      overrides: options?.contextOverrides?.steps,
+    },
+  ];
+
+  return rtlRender(
+    <RenderContexts contexts={contexts}>{component}</RenderContexts>
+  );
+}


### PR DESCRIPTION
## Summary

Today, we have many react components which rely on contexts for sharing state/functionality across the app without duplication or requiring re-nesting properties far down the component tree. This works very well for quickly sharing/implementing functionality. Unfortunately, reliance on `Context` comes at a cost in several areas. One of these areas is testing; because many components could rely on a context, that context must be implemented for each test. Because we haven't tested many components yet, we haven't really dealt with this cost.

As we start to get closer to a v1 level of quality, we're going to need to implement unit tests for components. In preparation for this, I've taken a stab at implementing some helper functions for our front-end to make it much quicker to write unit tests for React components.

## Implementation details

This code essentially introduces some middleware for the RTL `render` function. It overlays our contexts with some basic defaults defined that can be easily overridden. The RTL interaction on the caller side will remain unchanged.

## How to validate this change

You can modify a test to try this out if you wish, there are no user-facing effects.