### PR TITLE
feat: add result count e2e

### DIFF
--- a/e2e/services/electron.ts
+++ b/e2e/services/electron.ts
@@ -84,6 +84,11 @@ export class ElectronServiceFactory {
     return this.#recordingBrowserPage;
   }
 
+  async clickRunTest() {
+    const electronWindow = await this.getWindow();
+    await electronWindow.click("text=Replay steps");
+  }
+
   async waitForPageToBeIdle(timeout = 45000) {
     await this.#recordingBrowserPage.waitForLoadState("networkidle", {
       timeout,

--- a/e2e/tests/navigation.test.ts
+++ b/e2e/tests/navigation.test.ts
@@ -22,12 +22,28 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+import type { Server } from "http";
 import { ElectronServiceFactory, env } from "../services";
+import { createTestHttpServer } from "./testServer";
 
 const electronService = new ElectronServiceFactory();
 
-afterEach(() => {
-  electronService.terminate();
+let server: Server;
+let hostname: string;
+let port: number;
+let url: string;
+
+beforeEach(() => {
+  const { server: s, hostname: h, port: p } = createTestHttpServer();
+  server = s;
+  hostname = h;
+  port = p;
+  url = `http://${hostname}:${port}`;
+});
+
+afterEach(async () => {
+  await electronService.terminate();
+  server.close();
 });
 
 describe("Navigation", () => {
@@ -38,14 +54,12 @@ describe("Navigation", () => {
 
     await electronService.clickStartRecording();
     await electronService.waitForPageToBeIdle();
-    await electronService.navigateRecordingBrowser("http://example.com");
+    await electronService.navigateRecordingBrowser(url);
 
     expect(await electronWindow.$("text=2 Recorded Steps")).toBeTruthy();
     expect(
       await electronWindow.$(`text=Go to ${env.DEMO_APP_URL}`)
     ).toBeTruthy();
-    expect(
-      await electronWindow.$("text=Go to http://example.com/")
-    ).toBeTruthy();
+    expect(await electronWindow.$(`text=Go to ${url}`)).toBeTruthy();
   });
 });

--- a/e2e/tests/testResult.test.ts
+++ b/e2e/tests/testResult.test.ts
@@ -1,0 +1,45 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import { ElectronServiceFactory, env } from "../services";
+
+const electronService = new ElectronServiceFactory();
+
+afterEach(() => {
+  electronService.terminate();
+});
+
+describe("Steps", () => {
+  it("has the right number of step results", async () => {
+    const electronWindow = await electronService.getWindow();
+
+    await electronService.enterTestUrl(env.DEMO_APP_URL);
+
+    await electronService.clickStartRecording();
+    await electronService.waitForPageToBeIdle();
+    await electronService.clickRunTest();
+
+    expect(await electronWindow.$("text=1 success"));
+  });
+});

--- a/e2e/tests/testServer.ts
+++ b/e2e/tests/testServer.ts
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import http from "http";
+
+export function createTestHttpServer(hostname = "127.0.0.1", port = 8082) {
+  const server = http.createServer((_req, res) => {
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "text/plain");
+    res.end("Hello Elastic Synthetics Recorder");
+  });
+
+  server.listen(port, hostname);
+
+  server.on("error", err => {
+    // eslint-disable-next-line no-console
+    console.error(err);
+  });
+
+  return { server, hostname, port };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "synthetics-recorder",
-  "version": "0.0.1-alpha.3",
+  "version": "0.0.1-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "synthetics-recorder",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synthetics-recorder",
-  "version": "0.0.1-alpha.3",
+  "version": "0.0.1-alpha.2",
   "description": "Record synthetics user journey flow of a website",
   "repository": "https://github.com/elastic/synthetics-recorder",
   "scripts": {
@@ -23,7 +23,7 @@
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "jest --config ./jest.unit.config.js ./src",
     "test:unit:watch": "npm run test:unit -- --coverage --watch",
-    "test:e2e": "jest --config ./jest.e2e.config.js ./e2e/tests",
+    "test:e2e": "jest --runInBand --config ./jest.e2e.config.js ./e2e/tests",
     "test:e2e:server": "BROWSER=NONE PORT=61337 react-scripts start",
     "test:e2e:runner": "IS_RUNNER=true TEST_PORT=61337 jest --config ./jest.e2e.config.js ./e2e/tests",
     "update-demo-app": "git subtree pull --prefix demo-app git@github.com:vigneshshanmugam/synthetics-ecommerce-demo.git main --squash"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synthetics-recorder",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "description": "Record synthetics user journey flow of a website",
   "repository": "https://github.com/elastic/synthetics-recorder",
   "scripts": {

--- a/src/components/TestResult.tsx
+++ b/src/components/TestResult.tsx
@@ -152,8 +152,8 @@ export function TestResult() {
             return (
               <EuiFlexItem key={index} grow={false}>
                 <EuiText style={styles[key as ResultCategory]}>
-                  {symbols[keyAsCategory]} {result[keyAsCategory]}{" "}
-                  {text[keyAsCategory]}
+                  {symbols[keyAsCategory]}{" "}
+                  {`${result[keyAsCategory]} ${text[keyAsCategory]}`}
                 </EuiText>
               </EuiFlexItem>
             );


### PR DESCRIPTION
## Summary

Adds another e2e test, which verifies that the result count shows up as expected.

## Implementation details

We had some flaky/infra issues adding a second test. We've removed the external website dependency from the `navigation.test.ts` suite, and added a basic web server to check against navigations.

## How to validate this change

Run `npm run test:e2e` repeatedly and verify that the tests are both passing.