### PR TITLE
feat: Show all action titles in step containers for test result flyout

### DIFF
--- a/e2e/tests/testResult.test.ts
+++ b/e2e/tests/testResult.test.ts
@@ -42,5 +42,6 @@ describe("Steps", () => {
     await electronService.clickRunTest();
 
     expect(await electronWindow.$("text=1 success"));
+    expect(await electronWindow.$(`text=Go to http://${env.DEMO_APP_URL}`));
   });
 });

--- a/electron/execution.js
+++ b/electron/execution.js
@@ -140,7 +140,6 @@ function addActionsToStepResult(steps, event) {
     s =>
       s.length &&
       s[0].title &&
-      s[0].title &&
       event?.data?.name &&
       event.data.name === s[0].title
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,10 +61,15 @@ export default function App() {
   const { ipc } = useContext(CommunicationContext);
   const stepsContextUtils = useStepsContext();
   const { steps, setSteps } = stepsContextUtils;
-  const recordingContextUtils = useRecordingContext(ipc, url, steps.length);
+  const syntheticsTestUtils = useSyntheticsTest(steps);
+  const recordingContextUtils = useRecordingContext(
+    ipc,
+    url,
+    steps.length,
+    syntheticsTestUtils.setResult
+  );
   const { isStartOverModalVisible, setIsStartOverModalVisible, startOver } =
     recordingContextUtils;
-  const syntheticsTestUtils = useSyntheticsTest(steps);
 
   useEffect(() => {
     // `actions` here is a set of `ActionInContext`s that make up a `Step`

--- a/src/common/shared.test.ts
+++ b/src/common/shared.test.ts
@@ -156,7 +156,13 @@ describe("shared", () => {
       await getCodeForFailedResult(mockIpc, [failedStep], {
         status: "failed",
         type: "inline",
-        steps: [{ duration: 10, name: "I failed", status: "failed" }],
+        steps: [
+          {
+            duration: 10,
+            name: "I failed",
+            status: "failed",
+          },
+        ],
       });
 
       expect(mockIpc.callMain).toHaveBeenCalledTimes(1);

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -48,6 +48,7 @@ export type ResultCategory = StepStatus | "running";
 export interface JourneyStep {
   duration: number;
   error?: Error;
+  actionTitles?: string[];
   name: string;
   status: StepStatus;
 }

--- a/src/components/TestResult/ResultBody.tsx
+++ b/src/components/TestResult/ResultBody.tsx
@@ -22,29 +22,31 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { EuiFlexItem, EuiText } from "@elastic/eui";
+import { EuiFlexGroup, EuiFlexItem, EuiText } from "@elastic/eui";
 import React from "react";
 import type { StepStatus } from "../../common/types";
-import { ResultContentWithoutAccordion, symbols } from "./styles";
+import { ResultContentWrapper, symbols } from "./styles";
 
 interface IResultBody {
-  durationElement: JSX.Element;
-  name: string;
+  actionTitles: string[];
   resultCategory: StepStatus;
 }
 
-export function ResultBody({
-  durationElement,
-  name,
-  resultCategory,
-}: IResultBody) {
+export function ResultBody({ actionTitles, resultCategory }: IResultBody) {
   return (
-    <ResultContentWithoutAccordion alignItems="center" gutterSize="xs">
-      <EuiFlexItem grow={false}>{symbols[resultCategory]}</EuiFlexItem>
-      <EuiFlexItem>
-        <EuiText size="s">{name}</EuiText>
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>{durationElement}</EuiFlexItem>
-    </ResultContentWithoutAccordion>
+    <EuiFlexGroup direction="column" gutterSize="none">
+      {actionTitles.map((name, index) => (
+        <ResultContentWrapper
+          alignItems="center"
+          key={name + index}
+          gutterSize="xs"
+        >
+          <EuiFlexItem grow={false}>{symbols[resultCategory]}</EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText size="s">{name}</EuiText>
+          </EuiFlexItem>
+        </ResultContentWrapper>
+      ))}
+    </EuiFlexGroup>
   );
 }

--- a/src/components/TestResult/ResultErrorBody.tsx
+++ b/src/components/TestResult/ResultErrorBody.tsx
@@ -25,7 +25,7 @@ THE SOFTWARE.
 import { EuiFlexGroup, EuiFlexItem, EuiText, EuiCodeBlock } from "@elastic/eui";
 import React from "react";
 import type { StepStatus } from "../../common/types";
-import { ResultErrorAccordion, symbols } from "./styles";
+import { ResultContentWrapper, ResultErrorAccordion, symbols } from "./styles";
 
 function removeColorCodes(str = "") {
   // eslint-disable-next-line no-control-regex
@@ -34,50 +34,56 @@ function removeColorCodes(str = "") {
 
 export interface IResultErrorBody {
   code: string;
-  durationElement: JSX.Element;
   errorMessage?: string;
-  name: string;
+  actionTitles: string[];
   resultCategory: StepStatus;
   stepIndex: number;
   stepName: string;
 }
 
 export function ResultErrorBody({
+  actionTitles,
   code,
-  durationElement,
   errorMessage,
-  name,
   resultCategory,
   stepIndex,
   stepName,
 }: IResultErrorBody) {
   return (
-    <ResultErrorAccordion
-      id={stepName}
-      initialIsOpen
-      buttonContent={
-        <EuiFlexGroup alignItems="center" gutterSize="xs">
-          <EuiFlexItem grow={false}>{symbols[resultCategory]}</EuiFlexItem>
-          <EuiFlexItem>
-            <EuiText size="s">{name}</EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      }
-      extraAction={durationElement}
-      key={stepIndex}
-      paddingSize="s"
-      buttonClassName="euiAccordionForm__button"
-    >
-      {errorMessage && (
-        <>
-          <EuiCodeBlock language="js" paddingSize="m" whiteSpace="pre">
-            {code}
-          </EuiCodeBlock>
-          <EuiCodeBlock paddingSize="m">
-            {removeColorCodes(errorMessage)}
-          </EuiCodeBlock>
-        </>
-      )}
-    </ResultErrorAccordion>
+    <>
+      <EuiFlexGroup direction="column" gutterSize="none">
+        {actionTitles.map((name, index) => (
+          <ResultContentWrapper
+            alignItems="center"
+            gutterSize="xs"
+            key={name + index}
+          >
+            <EuiFlexItem grow={false}>{symbols[resultCategory]}</EuiFlexItem>
+            <EuiFlexItem>
+              <EuiText size="s">{name}</EuiText>
+            </EuiFlexItem>
+          </ResultContentWrapper>
+        ))}
+      </EuiFlexGroup>
+      <ResultErrorAccordion
+        id={stepName}
+        initialIsOpen
+        buttonContent="Step code"
+        key={stepIndex}
+        paddingSize="s"
+        buttonClassName="euiAccordionForm__button"
+      >
+        {errorMessage && (
+          <>
+            <EuiCodeBlock language="js" paddingSize="m" whiteSpace="pre">
+              {code}
+            </EuiCodeBlock>
+            <EuiCodeBlock paddingSize="m">
+              {removeColorCodes(errorMessage)}
+            </EuiCodeBlock>
+          </>
+        )}
+      </ResultErrorAccordion>
+    </>
   );
 }

--- a/src/components/TestResult/ResultFlyoutItem.tsx
+++ b/src/components/TestResult/ResultFlyoutItem.tsx
@@ -42,30 +42,29 @@ export function ResultFlyoutItem({
   step,
   stepIndex,
 }: IResultFlyoutItem) {
-  const { name, status, error, duration } = step;
+  const { actionTitles, status, error, duration } = step;
 
   const durationElement = (
     <EuiText size="s">{Math.round(duration / 1000)}s</EuiText>
   );
 
   return (
-    <ResultTitle key={key} titleText={`Step ${stepIndex + 1}`}>
+    <ResultTitle
+      durationElement={durationElement}
+      key={key}
+      titleText={`Step ${stepIndex + 1}`}
+    >
       {error ? (
         <ResultErrorBody
+          actionTitles={actionTitles ?? []}
           code={code}
-          durationElement={durationElement}
           errorMessage={error?.message}
-          name={name}
           resultCategory={status}
           stepIndex={stepIndex}
           stepName={step.name}
         />
       ) : (
-        <ResultBody
-          durationElement={durationElement}
-          name={name}
-          resultCategory={status}
-        />
+        <ResultBody actionTitles={actionTitles ?? []} resultCategory={status} />
       )}
     </ResultTitle>
   );

--- a/src/components/TestResult/ResultTitle.tsx
+++ b/src/components/TestResult/ResultTitle.tsx
@@ -22,23 +22,31 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+import { EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import React from "react";
 import { Bold, ResultContainer, ResultHeader } from "./styles";
 
 export interface IResultHeader {
+  durationElement: JSX.Element;
   key?: string;
   titleText: string;
 }
 
 export const ResultTitle: React.FC<IResultHeader> = ({
   children,
+  durationElement,
   key,
   titleText,
 }) => {
   return (
     <ResultContainer key={key} hasShadow={false}>
       <ResultHeader>
-        <Bold>{titleText}</Bold>
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <Bold>{titleText}</Bold>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>{durationElement}</EuiFlexItem>
+        </EuiFlexGroup>
       </ResultHeader>
       {children}
     </ResultContainer>

--- a/src/components/TestResult/styles.tsx
+++ b/src/components/TestResult/styles.tsx
@@ -41,17 +41,17 @@ export const ResultContainer = styled(EuiPanel)`
   margin: 0px 0px 24px 0px;
 `;
 
-export const ResultHeader = styled.div`
+export const ResultHeader = styled.h3`
   border-bottom: ${props => props.theme.border.thin};
   padding: 8px;
 `;
 
 export const ResultErrorAccordion = styled(EuiAccordion)`
-  margin-right: 8px;
+  margin: 0px 10px 0px 4px;
 `;
 
-export const ResultContentWithoutAccordion = styled(EuiFlexGroup)`
-  padding: 8px;
+export const ResultContentWrapper = styled(EuiFlexGroup)`
+  margin: 8px 8px 4px 8px;
 `;
 
 export const Bold = styled(EuiText)`

--- a/src/helpers/resultReducer.test.ts
+++ b/src/helpers/resultReducer.test.ts
@@ -48,6 +48,9 @@ describe("result reducer", () => {
       resultReducer(undefined, {
         event: "step/end",
         data: {
+          actionTitles: [
+            "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+          ],
           name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
           status: "succeeded",
           duration: 491,
@@ -62,6 +65,9 @@ describe("result reducer", () => {
         type: "inline",
         steps: [
           {
+            actionTitles: [
+              "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+            ],
             duration: 491,
             name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
             status: "succeeded",
@@ -76,6 +82,9 @@ describe("result reducer", () => {
       resultReducer(undefined, {
         event: "step/end",
         data: {
+          actionTitles: [
+            "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+          ],
           name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
           status: "failed",
           duration: 9000,
@@ -90,6 +99,9 @@ describe("result reducer", () => {
         type: "inline",
         steps: [
           {
+            actionTitles: [
+              "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+            ],
             duration: 9000,
             name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
             status: "failed",
@@ -104,6 +116,9 @@ describe("result reducer", () => {
       resultReducer(undefined, {
         event: "step/end",
         data: {
+          actionTitles: [
+            "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+          ],
           name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
           status: "skipped",
           duration: 0,
@@ -118,6 +133,9 @@ describe("result reducer", () => {
         type: "inline",
         steps: [
           {
+            actionTitles: [
+              "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+            ],
             duration: 0,
             name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
             status: "skipped",
@@ -139,6 +157,7 @@ describe("result reducer", () => {
             type: "inline",
             steps: [
               {
+                actionTitles: ["Go to https://www.elastic.co"],
                 duration: 100,
                 name: "Go to https://www.elastic.co",
                 status: "succeeded",
@@ -159,6 +178,7 @@ describe("result reducer", () => {
         status: "succeeded",
         steps: [
           {
+            actionTitles: ["Go to https://www.elastic.co"],
             duration: 100,
             name: "Go to https://www.elastic.co",
             status: "succeeded",
@@ -177,6 +197,9 @@ describe("result reducer", () => {
     const b = resultReducer(a, {
       event: "step/end",
       data: {
+        actionTitles: [
+          "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+        ],
         name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
         status: "succeeded",
         duration: 491,
@@ -185,6 +208,9 @@ describe("result reducer", () => {
     const c = resultReducer(b, {
       event: "step/end",
       data: {
+        actionTitles: [
+          "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+        ],
         name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
         status: "failed",
         duration: 9000,
@@ -193,6 +219,10 @@ describe("result reducer", () => {
     const d = resultReducer(c, {
       event: "step/end",
       data: {
+        actionTitles: [
+          "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+          "A second action",
+        ],
         name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
         status: "skipped",
         duration: 0,
@@ -211,16 +241,26 @@ describe("result reducer", () => {
         type: "inline",
         steps: [
           {
+            actionTitles: [
+              "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+            ],
             name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
             status: "succeeded",
             duration: 491,
           },
           {
+            actionTitles: [
+              "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+            ],
             name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
             status: "failed",
             duration: 9000,
           },
           {
+            actionTitles: [
+              "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+              "A second action",
+            ],
             duration: 0,
             name: "Go to https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
             status: "skipped",

--- a/src/hooks/useRecordingContext.ts
+++ b/src/hooks/useRecordingContext.ts
@@ -38,7 +38,8 @@ import { IRecordingContext } from "../contexts/RecordingContext";
 export function useRecordingContext(
   ipc: RendererProcessIpc,
   url: string,
-  stepCount: number
+  stepCount: number,
+  setResult: (data: undefined) => void
 ): IRecordingContext {
   const [isStartOverModalVisible, setIsStartOverModalVisible] = useState(false);
   const [recordingStatus, setRecordingStatus] = useState(
@@ -61,10 +62,13 @@ export function useRecordingContext(
   const startOver = useCallback(async () => {
     if (recordingStatus === RecordingStatus.NotRecording) {
       setRecordingStatus(RecordingStatus.Recording);
+      // Depends on the results context, because when we overwrite
+      // a previous journey we need to discard its result status
+      setResult(undefined);
       await ipc.callMain("record-journey", { url });
       setRecordingStatus(RecordingStatus.NotRecording);
     }
-  }, [ipc, recordingStatus, url]);
+  }, [ipc, recordingStatus, setResult, url]);
 
   const togglePause = async () => {
     if (recordingStatus === RecordingStatus.NotRecording) return;

--- a/src/hooks/useSyntheticsTest.ts
+++ b/src/hooks/useSyntheticsTest.ts
@@ -57,6 +57,7 @@ export function useSyntheticsTest(steps: Steps): ITestContext {
 
         try {
           const promise = ipc.callMain("run-journey", {
+            steps,
             code,
             isSuite: false,
           });


### PR DESCRIPTION
## Summary

Resolves #131.

As pictured below, shows all the actions in the result panels:

<img width="808" alt="image" src="https://user-images.githubusercontent.com/18429259/154344249-ea8050cb-4200-4312-844a-26bc350b5adc.png">

### Things to note

I have moved the duration value to the top of the step panel, because otherwise the duration element is appended to all of the actions and is misleading. Today, we only have resolution to the step level in terms of duration.

I am working on some [upstream changes](https://github.com/elastic/synthetics/pull/457) to Synthetics that should allow us to get action-level performance. At that point, we should be able to supply duration value for each item in this list, along with a cumulative duration value displayed in the heading.

Because we don't have action-level resolution, this means that all actions within a step currently show as the same status. If one action fails, all the actions in the step need to be marked as failure, because we currently do not know which one it was. Once the above changes are merged, we should be able to fix this.


## Implementation details

The backend electron code has been updated to find and supply the titles for all the actions contained in a given step. Given the constraints we have imposed on how step names are interpolated by the backend, we should always be able to parse out the original step data and retrieve the action titles for it, based on the event data that Playwright returns to the recorder.

When the client receives the event data, it will now use the supplied `actionTitles` field to display all the actions that the step contained.

## How to validate this change

1. Record a series of steps, preferably three or more.
2. Insert an assertion into the middle step that should cause the step to fail.
3. Test your script.
4. Observe that the first step shows succeeded, as per the screenshot pictured above. Observe the second step shows the usual failure information, along with the code. Observe that the remaining steps are shown as skipped, along with all of their action titles.