### PR TITLE
feat: Add tooltip to assertion element heading

### DIFF
--- a/e2e/services/electron.ts
+++ b/e2e/services/electron.ts
@@ -94,6 +94,18 @@ export class ElectronServiceFactory {
     await electronWindow.click("text=Stop");
   }
 
+  async clickActionElementSettingsButton(
+    elementSelector: string,
+    buttonSelector: string
+  ) {
+    const electronWindow = await this.getWindow();
+    await electronWindow.hover(elementSelector);
+    await electronWindow.click(
+      `[aria-label="Expand the settings menu for this action"]`
+    );
+    return electronWindow.click(buttonSelector);
+  }
+
   async waitForPageToBeIdle(timeout = 45000) {
     await this.#recordingBrowserPage.waitForLoadState("networkidle", {
       timeout,

--- a/e2e/tests/assertionInfo.test.ts
+++ b/e2e/tests/assertionInfo.test.ts
@@ -1,0 +1,60 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import { ElectronServiceFactory, env } from "../services";
+
+const electronService = new ElectronServiceFactory();
+
+afterEach(async () => {
+  await electronService.terminate();
+});
+
+describe("Assertion Info Popover", () => {
+  it("creates a link to playwright docs on assertion info popover", async () => {
+    const electronWindow = await electronService.getWindow();
+    await electronService.enterTestUrl(env.DEMO_APP_URL);
+    await electronService.clickStartRecording();
+    await electronService.waitForPageToBeIdle();
+    await electronService.clickStopRecording();
+    await electronService.clickActionElementSettingsButton(
+      "id=action-element-0-0",
+      "text=Add assertion"
+    );
+    await electronWindow.click("id=action-element-0-1");
+    await electronWindow.hover("id=action-element-0-1");
+    await electronWindow.click(
+      `[aria-label="Begin editing this action"] >> nth=1`
+    );
+    await electronWindow.click(
+      `[aria-label="Shows a popover with more information about Playwright assertions."]`
+    );
+
+    expect(
+      await electronWindow.$(
+        "text=You can add assertions to validate your page's content matches your expectations."
+      )
+    ).toBeTruthy();
+    expect(await electronWindow.$("text=Read more")).toBeTruthy();
+  });
+});

--- a/src/common/shared.ts
+++ b/src/common/shared.ts
@@ -64,6 +64,9 @@ export const COMMAND_SELECTOR_OPTIONS = [
 export const SYNTHETICS_DISCUSS_FORUM_URL =
   "https://forms.gle/PzVtYoExfqQ9UMkY6";
 
+export const PLAYWRIGHT_ASSERTION_DOCS_LINK =
+  "https://playwright.dev/docs/assertions/";
+
 export const SMALL_SCREEN_BREAKPOINT = 850;
 
 export function performSelectorLookup(

--- a/src/components/ActionElement/ActionElement.tsx
+++ b/src/components/ActionElement/ActionElement.tsx
@@ -89,7 +89,11 @@ function ActionComponent({
   );
 
   return (
-    <Container className={className} gutterSize="none">
+    <Container
+      className={className}
+      id={`action-element-${stepIndex}-${actionIndex}`}
+      gutterSize="none"
+    >
       <EuiFlexItem grow={false}>
         {!step.action.isAssert && (
           <ActionStatusIndicator showRect={isLast} status={testStatus} />

--- a/src/components/Assertion/Assertion.tsx
+++ b/src/components/Assertion/Assertion.tsx
@@ -33,7 +33,7 @@ import {
   EuiFormRow,
   EuiIcon,
   EuiSpacer,
-  EuiText,
+  EuiToolTip,
 } from "@elastic/eui";
 import type { Action } from "../../common/types";
 import { StepsContext } from "../../contexts/StepsContext";
@@ -87,12 +87,19 @@ export function Assertion({
     <>
       <EuiFlexGroup alignItems="center" gutterSize="s">
         <EuiFlexItem grow={false}>
-          <EuiText>
-            <h4>Add assertion</h4>
-          </EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiIcon type="iInCircle" />
+          <EuiFlexGroup alignItems="center" gutterSize="s">
+            <EuiFlexItem grow={false}>
+              <h4>Add assertion</h4>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiToolTip
+                title="Add assertion"
+                content="You can add assertions to validate your page's content matches your expectations."
+              >
+                <EuiIcon type="iInCircle" />
+              </EuiToolTip>
+            </EuiFlexItem>
+          </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer />

--- a/src/components/Assertion/Assertion.tsx
+++ b/src/components/Assertion/Assertion.tsx
@@ -31,13 +31,12 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
-  EuiIcon,
   EuiSpacer,
-  EuiToolTip,
 } from "@elastic/eui";
 import type { Action } from "../../common/types";
 import { StepsContext } from "../../contexts/StepsContext";
 import { AssertionSelect } from "./Select";
+import { AssertionInfo } from "./AssertionInfo";
 
 interface IAssertion {
   action: Action;
@@ -92,12 +91,7 @@ export function Assertion({
               <h4>Add assertion</h4>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiToolTip
-                title="Add assertion"
-                content="You can add assertions to validate your page's content matches your expectations."
-              >
-                <EuiIcon type="iInCircle" />
-              </EuiToolTip>
+              <AssertionInfo />
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>

--- a/src/components/Assertion/AssertionInfo.tsx
+++ b/src/components/Assertion/AssertionInfo.tsx
@@ -48,6 +48,11 @@ const InfoPopoverTextWrapper = styled(EuiText)`
   padding: 8px;
 `;
 
+const AssertionInfoText = styled(EuiText)`
+  padding-left: 8px;
+  max-width: 280px;
+`;
+
 export function AssertionInfo() {
   const [isInfoPopoverOpen, setIsInfoPopoverOpen] = useState(false);
   const { ipc } = useContext(CommunicationContext);
@@ -68,10 +73,16 @@ export function AssertionInfo() {
         <h4>Add assertion</h4>
       </InfoPopoverTitle>
       <InfoPopoverTextWrapper>
-        <EuiFlexGroup alignItems="baseline" gutterSize="none">
+        <EuiFlexGroup
+          alignItems="flexStart"
+          direction="column"
+          gutterSize="none"
+        >
           <EuiFlexItem grow={false}>
-            You can add assertions to validate your page&apos;s content matches
-            your expectations.
+            <AssertionInfoText>
+              You can add assertions to validate your page&apos;s content
+              matches your expectations.
+            </AssertionInfoText>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiButtonEmpty

--- a/src/components/Assertion/AssertionInfo.tsx
+++ b/src/components/Assertion/AssertionInfo.tsx
@@ -33,7 +33,10 @@ import {
 } from "@elastic/eui";
 import React, { useContext, useState } from "react";
 import styled from "styled-components";
-import { createExternalLinkHandler } from "../../common/shared";
+import {
+  createExternalLinkHandler,
+  PLAYWRIGHT_ASSERTION_DOCS_LINK,
+} from "../../common/shared";
 import { CommunicationContext } from "../../contexts/CommunicationContext";
 
 const InfoPopoverTitle = styled(EuiTitle)`
@@ -44,9 +47,6 @@ const InfoPopoverTitle = styled(EuiTitle)`
 const InfoPopoverTextWrapper = styled(EuiText)`
   padding: 8px;
 `;
-
-const PLAYWRIGHT_ASSERTION_DOCS_LINK =
-  "https://playwright.dev/docs/assertions/";
 
 export function AssertionInfo() {
   const [isInfoPopoverOpen, setIsInfoPopoverOpen] = useState(false);

--- a/src/components/Assertion/AssertionInfo.tsx
+++ b/src/components/Assertion/AssertionInfo.tsx
@@ -1,0 +1,91 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import {
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopover,
+  EuiText,
+  EuiTitle,
+} from "@elastic/eui";
+import React, { useContext, useState } from "react";
+import styled from "styled-components";
+import { createExternalLinkHandler } from "../../common/shared";
+import { CommunicationContext } from "../../contexts/CommunicationContext";
+
+const InfoPopoverTitle = styled(EuiTitle)`
+  border-bottom: ${props => props.theme.border.thin};
+  padding: 8px;
+`;
+
+const InfoPopoverTextWrapper = styled(EuiText)`
+  padding: 8px;
+`;
+
+const PLAYWRIGHT_ASSERTION_DOCS_LINK =
+  "https://playwright.dev/docs/assertions/";
+
+export function AssertionInfo() {
+  const [isInfoPopoverOpen, setIsInfoPopoverOpen] = useState(false);
+  const { ipc } = useContext(CommunicationContext);
+  return (
+    <EuiPopover
+      button={
+        <EuiButtonIcon
+          aria-label="Shows a popover with more information about Playwright assertions."
+          iconType="iInCircle"
+          onClick={() => setIsInfoPopoverOpen(!isInfoPopoverOpen)}
+        />
+      }
+      isOpen={isInfoPopoverOpen}
+      closePopover={() => setIsInfoPopoverOpen(false)}
+      panelPaddingSize="none"
+    >
+      <InfoPopoverTitle size="xs">
+        <h4>Add assertion</h4>
+      </InfoPopoverTitle>
+      <InfoPopoverTextWrapper>
+        <EuiFlexGroup alignItems="baseline" gutterSize="none">
+          <EuiFlexItem grow={false}>
+            You can add assertions to validate your page&apos;s content matches
+            your expectations.
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              href={PLAYWRIGHT_ASSERTION_DOCS_LINK}
+              onClick={createExternalLinkHandler(
+                ipc,
+                PLAYWRIGHT_ASSERTION_DOCS_LINK
+              )}
+            >
+              Read more
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </InfoPopoverTextWrapper>
+    </EuiPopover>
+  );
+}


### PR DESCRIPTION
## Summary

Resolves #65.

Adds a tooltip to the assertion element's heading per the designs.

<img width="639" alt="image" src="https://user-images.githubusercontent.com/18429259/154353559-cc1a60fd-3bfd-47a6-831f-a45eebc3e2a5.png">


## Implementation details

Note: it does not include a link as the design indicates. I'm not sure what location that link should go to, and the tooltip's default behavior is to collapse when the mouse is no longer hover on the child element.

We can modify this implementation by fleshing out this requirement more.

## How to validate this change

Record steps, insert an assertion, edit it and see the tooltip appear over the icon.