### PR TITLE
fix: Show label as tooltip when the viewport width is small

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,7 +48,6 @@ module.exports = {
       rules: {
         "@typescript-eslint/explicit-module-boundary-types": 0,
         "@typescript-eslint/no-non-null-assertion": 0,
-        "jsx-a11y/aria-props": 0, // aria-description bug https://github.com/facebook/react/issues/21035
       },
     },
   ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,6 +48,7 @@ module.exports = {
       rules: {
         "@typescript-eslint/explicit-module-boundary-types": 0,
         "@typescript-eslint/no-non-null-assertion": 0,
+        "jsx-a11y/aria-props": 0, // aria-description bug https://github.com/facebook/react/issues/21035
       },
     },
   ],

--- a/e2e/tests/runTest.test.ts
+++ b/e2e/tests/runTest.test.ts
@@ -38,9 +38,7 @@ describe("Test Button", () => {
     await electronService.clickStartRecording();
     await electronService.waitForPageToBeIdle();
 
-    const testButton = await electronWindow.$(
-      `[aria-label="You cannot execute your recorded tests until you have finished a recording session"]`
-    );
+    const testButton = await electronWindow.$(`[aria-label="Test"]`);
     expect(testButton).toBeTruthy();
     expect(await testButton.isEnabled());
   });

--- a/src/components/ControlButton.tsx
+++ b/src/components/ControlButton.tsx
@@ -57,7 +57,7 @@ export const ControlButton: React.FC<Props> = props => {
     return () => window.removeEventListener("resize", evaluateSize);
   }, [l, showIconOnly]);
 
-  const { children, fill, tooltipContent, ...rest } = props;
+  const { fill, tooltipContent, ...rest } = props;
   if (showIconOnly) {
     return (
       <EuiToolTip content={tooltipContent || props["aria-label"]}>
@@ -68,7 +68,7 @@ export const ControlButton: React.FC<Props> = props => {
 
   return (
     <EuiToolTip content={tooltipContent} delay="long">
-      <EuiButton {...rest} />
+      <EuiButton fill {...rest} />
     </EuiToolTip>
   );
 };

--- a/src/components/ControlButton.tsx
+++ b/src/components/ControlButton.tsx
@@ -28,11 +28,13 @@ import {
   EuiButtonIcon,
   EuiButtonIconProps,
   EuiThemeContext,
+  EuiToolTip,
 } from "@elastic/eui";
 import React, { useContext, useEffect, useState } from "react";
 
 interface IControlButton {
   onClick: React.MouseEventHandler<HTMLButtonElement>;
+  "aria-description"?: string;
 }
 
 type Props = IControlButton & EuiButtonIconProps & EuiButtonProps;
@@ -58,8 +60,15 @@ export const ControlButton: React.FC<Props> = props => {
   if (showIconOnly) {
     const { children, fill, ...rest } = props;
     return (
-      <EuiButtonIcon display={fill ? "fill" : "base"} size="m" {...rest} />
+      <EuiToolTip content={props["aria-label"]}>
+        <EuiButtonIcon display={fill ? "fill" : "base"} size="m" {...rest} />
+      </EuiToolTip>
     );
   }
-  return <EuiButton {...props} />;
+
+  return (
+    <EuiToolTip content={props["aria-description"]} delay="long">
+      <EuiButton {...props} />
+    </EuiToolTip>
+  );
 };

--- a/src/components/ControlButton.tsx
+++ b/src/components/ControlButton.tsx
@@ -57,8 +57,8 @@ export const ControlButton: React.FC<Props> = props => {
     return () => window.removeEventListener("resize", evaluateSize);
   }, [l, showIconOnly]);
 
+  const { children, fill, tooltipContent, ...rest } = props;
   if (showIconOnly) {
-    const { children, fill, tooltipContent, ...rest } = props;
     return (
       <EuiToolTip content={tooltipContent || props["aria-label"]}>
         <EuiButtonIcon display={fill ? "fill" : "base"} size="m" {...rest} />
@@ -67,8 +67,8 @@ export const ControlButton: React.FC<Props> = props => {
   }
 
   return (
-    <EuiToolTip content={props.tooltipContent} delay="long">
-      <EuiButton {...props} />
+    <EuiToolTip content={tooltipContent} delay="long">
+      <EuiButton {...rest} />
     </EuiToolTip>
   );
 };

--- a/src/components/ControlButton.tsx
+++ b/src/components/ControlButton.tsx
@@ -34,7 +34,7 @@ import React, { useContext, useEffect, useState } from "react";
 
 interface IControlButton {
   onClick: React.MouseEventHandler<HTMLButtonElement>;
-  "aria-description"?: string;
+  tooltipContent?: string;
 }
 
 type Props = IControlButton & EuiButtonIconProps & EuiButtonProps;
@@ -58,16 +58,16 @@ export const ControlButton: React.FC<Props> = props => {
   }, [l, showIconOnly]);
 
   if (showIconOnly) {
-    const { children, fill, ...rest } = props;
+    const { children, fill, tooltipContent, ...rest } = props;
     return (
-      <EuiToolTip content={props["aria-label"]}>
+      <EuiToolTip content={tooltipContent || props["aria-label"]}>
         <EuiButtonIcon display={fill ? "fill" : "base"} size="m" {...rest} />
       </EuiToolTip>
     );
   }
 
   return (
-    <EuiToolTip content={props["aria-description"]} delay="long">
+    <EuiToolTip content={props.tooltipContent} delay="long">
       <EuiButton {...props} />
     </EuiToolTip>
   );

--- a/src/components/Header/HeaderControls.test.tsx
+++ b/src/components/Header/HeaderControls.test.tsx
@@ -28,14 +28,12 @@ import { HeaderControls } from "./HeaderControls";
 import { render } from "../../helpers/test";
 
 describe("<HeaderControls />", () => {
-  const START_ARIA = "Toggle the script recorder between recording and paused";
-
   it("displays start text when not recording", async () => {
     const { getByLabelText } = render(
       <HeaderControls setIsCodeFlyoutVisible={jest.fn()} />
     );
 
-    expect(getByLabelText(START_ARIA).textContent).toBe("Start");
+    expect(getByLabelText("Start")).toBeTruthy();
   });
 
   it("displays pause text when recording", () => {
@@ -49,7 +47,7 @@ describe("<HeaderControls />", () => {
       }
     );
 
-    expect(getByLabelText(START_ARIA).textContent).toBe("Pause");
+    expect(getByLabelText("Pause")).toBeTruthy();
   });
 
   it("displays resume text when paused", () => {
@@ -63,6 +61,6 @@ describe("<HeaderControls />", () => {
       }
     );
 
-    expect(getByLabelText(START_ARIA).textContent).toBe("Resume");
+    expect(getByLabelText("Resume")).toBeTruthy();
   });
 });

--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -87,7 +87,6 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
       <EuiFlexItem grow={false}>
         <ControlButton
           aria-label={getPlayControlCopy(recordingStatus, steps.length)}
-          aria-description="Toggle the script recorder between recording and paused"
           color="primary"
           isDisabled={isTestInProgress}
           iconType={
@@ -107,7 +106,6 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
         <EuiFlexItem grow={false}>
           <ControlButton
             aria-label="Stop"
-            aria-description="Stop recording and clear all recorded actions"
             isDisabled={recordingStatus !== RecordingStatus.Recording}
             color="primary"
             iconType="stop"
@@ -137,7 +135,6 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
           <EuiFlexItem>
             <ControlButton
               aria-label="Export"
-              aria-description="Export recorded steps to a location you specify"
               isDisabled={steps.length === 0}
               iconType="exportAction"
               fill

--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -86,7 +86,8 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
       )}
       <EuiFlexItem grow={false}>
         <ControlButton
-          aria-label="Toggle the script recorder between recording and paused"
+          aria-label={getPlayControlCopy(recordingStatus, steps.length)}
+          aria-description="Toggle the script recorder between recording and paused"
           color="primary"
           isDisabled={isTestInProgress}
           iconType={
@@ -105,7 +106,8 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
       {recordingStatus !== RecordingStatus.NotRecording && (
         <EuiFlexItem grow={false}>
           <ControlButton
-            aria-label="Stop recording and clear all recorded actions"
+            aria-label="Stop"
+            aria-description="Stop recording and clear all recorded actions"
             isDisabled={recordingStatus !== RecordingStatus.Recording}
             color="primary"
             iconType="stop"
@@ -134,7 +136,8 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
           </TestButtonDivider>
           <EuiFlexItem>
             <ControlButton
-              aria-label="Export recorded steps to a location you specify"
+              aria-label="Export"
+              aria-description="Export recorded steps to a location you specify"
               isDisabled={steps.length === 0}
               iconType="exportAction"
               fill

--- a/src/components/TestButton.tsx
+++ b/src/components/TestButton.tsx
@@ -22,7 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { EuiToolTip } from "@elastic/eui";
 import React from "react";
 import { ControlButton } from "./ControlButton";
 
@@ -32,11 +31,12 @@ interface Props {
 }
 
 export function TestButton({ isDisabled, onTest }: Props) {
-  const button = (
+  return (
     <ControlButton
-      aria-label={
+      aria-label="Test"
+      aria-description={
         isDisabled
-          ? "You cannot execute your recorded tests until you have finished a recording session"
+          ? "Record a step in order to run a test"
           : "Perform a test run for the journey you have recorded"
       }
       color="primary"
@@ -47,14 +47,4 @@ export function TestButton({ isDisabled, onTest }: Props) {
       Test
     </ControlButton>
   );
-
-  if (isDisabled) {
-    return (
-      <EuiToolTip content="Record a step in order to run a test" delay="long">
-        {button}
-      </EuiToolTip>
-    );
-  }
-
-  return button;
 }

--- a/src/components/TestButton.tsx
+++ b/src/components/TestButton.tsx
@@ -34,11 +34,7 @@ export function TestButton({ isDisabled, onTest }: Props) {
   return (
     <ControlButton
       aria-label="Test"
-      aria-description={
-        isDisabled
-          ? "Record a step in order to run a test"
-          : "Perform a test run for the journey you have recorded"
-      }
+      tooltipContent={isDisabled ? "Record a step in order to run a test" : ""}
       color="primary"
       iconType="beaker"
       isDisabled={isDisabled}


### PR DESCRIPTION
## Summary

closes #163 

When the recorder's viewport width is smaller than a certain size, the buttons hide the label and only show the icon. This PR adds a tooltip to the buttons when the label is disappeared due to mentioned reason.

Although there are some things to be clarified before merging this PR:
- [x]  Some of the buttons [already have tooltip](https://github.com/elastic/synthetics-recorder/issues/163#issuecomment-1067846533). Should the label take precedence over the description? or do we merge those two contents into a tooltip?
- [x] ~If we were to display descriptions for the buttons, revisit the wordings.~

- When the script is not recorded yet, the test button shows a tooltip with a descriptive message rather than a label (as it was before)
[![Image from Gyazo](https://i.gyazo.com/c732e9d5620a32d3971b13e7f8b8df06.gif)](https://gyazo.com/c732e9d5620a32d3971b13e7f8b8df06)

- When the script is recorded, the test button also shows a label
[![Image from Gyazo](https://i.gyazo.com/ef1a73d5bbab0b77b3178d2b2e1510db.gif)](https://gyazo.com/ef1a73d5bbab0b77b3178d2b2e1510db)
