### PR TITLE
feat: switch `Steps` data structure from nested array to map

### DIFF
--- a/e2e/tests/navigation.test.ts
+++ b/e2e/tests/navigation.test.ts
@@ -57,7 +57,6 @@ describe("Navigation", () => {
     await electronService.navigateRecordingBrowser(url);
 
     expect(await electronWindow.$("text=Step 1")).toBeTruthy();
-    expect(await electronWindow.$("text=Step 2")).toBeTruthy();
     expect(
       await electronWindow.$(`text=navigate ${env.DEMO_APP_URL}`)
     ).toBeTruthy();

--- a/electron/execution.js
+++ b/electron/execution.js
@@ -298,8 +298,8 @@ async function onFileSave(code) {
 
 async function onTransformCode(data) {
   const generator = new SyntheticsGenerator(data.isSuite);
-  const code = generator.generateText(data.actions);
-  return code;
+  const code = generator.generateFromSteps(data.actions);
+  return code.join("\n");
 }
 
 async function onSetMode(mode) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1846,25 +1846,30 @@
       }
     },
     "@elastic/synthetics": {
-      "version": "1.0.0-beta.19",
-      "resolved": "https://registry.npmjs.org/@elastic/synthetics/-/synthetics-1.0.0-beta.19.tgz",
-      "integrity": "sha512-/YKdql1ldJh2yn0U49Txi8a5e51BOIY1lIDGriZPXSBBgWjuWGKTBvpj/Ut35IvEFB6rGkC7mPqrYiJ3MKi2Fg==",
+      "version": "1.0.0-beta.23",
+      "resolved": "https://registry.npmjs.org/@elastic/synthetics/-/synthetics-1.0.0-beta.23.tgz",
+      "integrity": "sha512-fswPEO1GUxwmekn8TFTFGXaB8lPeaW6ai8+SK+5bqD9aR5sE6bzGL5613v5+dFjMell+r0ST0kRjc8Ggzntbmg==",
       "requires": {
-        "commander": "^7.0.0",
+        "@cspotcode/source-map-support": "^0.7.0",
+        "commander": "^9.0.0",
         "deepmerge": "^4.2.2",
         "expect": "^27.0.2",
         "http-proxy": "^1.18.1",
-        "kleur": "^4.1.3",
+        "kleur": "^4.1.4",
         "micromatch": "^4.0.4",
         "playwright-chromium": "=1.14.0",
-        "sharp": "^0.29.3",
+        "sharp": "^0.30.1",
         "snakecase-keys": "^3.2.1",
         "sonic-boom": "^2.6.0",
-        "source-map-support": "^0.5.19",
-        "ts-node": "^10.2.1",
-        "typescript": "^4.3.5"
+        "ts-node": "^10.7.0",
+        "typescript": "^4.5.5"
       },
       "dependencies": {
+        "commander": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.1.0.tgz",
+          "integrity": "sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w=="
+        },
         "playwright-chromium": {
           "version": "1.14.0",
           "resolved": "https://registry.npmjs.org/playwright-chromium/-/playwright-chromium-1.14.0.tgz",
@@ -5476,7 +5481,8 @@
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
     },
     "buffer-indexof": {
       "version": "1.1.1",
@@ -6051,9 +6057,9 @@
       }
     },
     "color": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.0.tgz",
-      "integrity": "sha512-hHTcrbvEnGjC7WBMk6ibQWFVDgEFTVmjrz2Q5HlU6ltwxv0JJN2Z8I7uRbWeQLF04dikxs8zgyZkazRJvSMtyQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.1.tgz",
+      "integrity": "sha512-MFJr0uY4RvTQUKvPq7dh9grVOTYSFeXja2mBXioCGjnjJoXrAp9jJ1NQTDR73c9nwBSAQiNKloKl5zq9WB9UPw==",
       "requires": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -6115,7 +6121,8 @@
     "commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true
     },
     "common-path-prefix": {
       "version": "3.0.0",
@@ -6959,9 +6966,9 @@
       "dev": true
     },
     "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -15549,13 +15556,6 @@
         "simple-get": "^4.0.0",
         "tar-fs": "^2.0.0",
         "tunnel-agent": "^0.6.0"
-      },
-      "dependencies": {
-        "detect-libc": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.0.tgz",
-          "integrity": "sha512-S55LzUl8HUav8l9E2PBTlC5PAJrHK7tkM+XXFGD+fbsbkTzhCpG6K05LxJcUOEWzMa4v6ptcMZ9s3fOdJDu0Zw=="
-        }
       }
     },
     "prelude-ls": {
@@ -18301,16 +18301,16 @@
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "sharp": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.29.3.tgz",
-      "integrity": "sha512-fKWUuOw77E4nhpyzCCJR1ayrttHoFHBT2U/kR/qEMRhvPEcluG4BKj324+SCO1e84+knXHwhJ1HHJGnUt4ElGA==",
+      "version": "0.30.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.3.tgz",
+      "integrity": "sha512-rjpfJFK58ZOFSG8sxYSo3/JQb4ej095HjXp9X7gVu7gEn1aqSG8TCW29h/Rr31+PXrFADo1H/vKfw0uhMQWFtg==",
       "requires": {
-        "color": "^4.0.1",
-        "detect-libc": "^1.0.3",
-        "node-addon-api": "^4.2.0",
-        "prebuild-install": "^7.0.0",
+        "color": "^4.2.1",
+        "detect-libc": "^2.0.1",
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1",
         "semver": "^7.3.5",
-        "simple-get": "^4.0.0",
+        "simple-get": "^4.0.1",
         "tar-fs": "^2.1.1",
         "tunnel-agent": "^0.6.0"
       }
@@ -18599,7 +18599,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-js": {
       "version": "1.0.1",
@@ -18635,6 +18636,7 @@
       "version": "0.5.20",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
       "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -19657,9 +19659,9 @@
       }
     },
     "ts-node": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.5.0.tgz",
-      "integrity": "sha512-6kEJKwVxAJ35W4akuiysfKwKmjkbYxwQMTBaAxo9KKAx/Yd26mPUyhGz3ji+EsJoAgrLqVsYHNuuYwQe22lbtw==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
       "requires": {
         "@cspotcode/source-map-support": "0.7.0",
         "@tsconfig/node10": "^1.0.7",
@@ -19774,9 +19776,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg=="
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
     "@elastic/eui": "^52.1.0",
-    "@elastic/synthetics": "=1.0.0-beta.19",
+    "@elastic/synthetics": "=1.0.0-beta.23",
     "@emotion/cache": "^11.7.1",
     "@emotion/react": "^11.8.2",
     "dotenv": "^10.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ import React, { useContext } from "react";
 import { useEffect, useState } from "react";
 import { EuiCode, EuiEmptyPrompt, EuiProvider } from "@elastic/eui";
 import createCache from "@emotion/cache";
-import type { ActionInContext, Step, Steps } from "@elastic/synthetics";
+import type { ActionInContext, Steps } from "@elastic/synthetics";
 import "./App.css";
 import "@elastic/eui/dist/eui_theme_light.css";
 import { Title } from "./components/Header/Title";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -116,7 +116,7 @@ export default function App() {
                       }
                     />
                   )}
-                  {steps.map((step: Step, index: number) => (
+                  {steps.map((step, index) => (
                     <StepSeparator
                       index={index}
                       key={`step-separator-${index + 1}`}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import React, { useContext } from "react";
 import { useEffect, useState } from "react";
 import { EuiCode, EuiEmptyPrompt, EuiProvider } from "@elastic/eui";
 import createCache from "@emotion/cache";
+import type { ActionInContext, Step, Steps } from "@elastic/synthetics";
 import "./App.css";
 import "@elastic/eui/dist/eui_theme_light.css";
 import { Title } from "./components/Header/Title";
@@ -34,7 +35,6 @@ import { RecordingContext } from "./contexts/RecordingContext";
 import { UrlContext } from "./contexts/UrlContext";
 import { StepsContext } from "./contexts/StepsContext";
 import { TestContext } from "./contexts/TestContext";
-import type { Step, Steps } from "./common/types";
 import { useSyntheticsTest } from "./hooks/useSyntheticsTest";
 import { generateIR, generateMergedIR } from "./helpers/generator";
 import { StepSeparator } from "./components/StepSeparator";
@@ -47,7 +47,6 @@ import { StyledComponentsEuiProvider } from "./contexts/StyledComponentsEuiProvi
 import { ExportScriptFlyout } from "./components/ExportScriptFlyout";
 import { useRecordingContext } from "./hooks/useRecordingContext";
 import { StartOverWarningModal } from "./components/StartOverWarningModal";
-import { ActionInContext } from "@elastic/synthetics";
 
 /**
  * This is the prescribed workaround to some internal EUI issues that occur
@@ -81,7 +80,7 @@ export default function App() {
   useEffect(() => {
     // `actions` here is a set of `ActionInContext`s that make up a `Step`
     const listener = ({ actions }: { actions: ActionInContext[] }) => {
-      setSteps(prevSteps => {
+      setSteps((prevSteps: Steps) => {
         const nextSteps: Steps = generateIR([{ actions }]);
         return generateMergedIR(prevSteps, nextSteps);
       });
@@ -117,7 +116,7 @@ export default function App() {
                       }
                     />
                   )}
-                  {steps.map((step, index) => (
+                  {steps.map((step: Step, index: number) => (
                     <StepSeparator
                       index={index}
                       key={`step-separator-${index + 1}`}

--- a/src/common/shared.test.ts
+++ b/src/common/shared.test.ts
@@ -29,64 +29,66 @@ import type { Step, Steps } from "./types";
 describe("shared", () => {
   describe("updateAction", () => {
     const steps: Steps = [
-      [
-        {
-          pageAlias: "page",
-          isMainFrame: true,
-          frameUrl: "http://localhost:12349/html",
-          committed: true,
-          action: {
-            name: "navigate",
-            url: "http://localhost:12349/html",
-            signals: [],
+      {
+        actions: [
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl: "http://localhost:12349/html",
+            committed: true,
+            action: {
+              name: "navigate",
+              url: "http://localhost:12349/html",
+              signals: [],
+            },
+            title: "Go to http://localhost:12349/html",
           },
-          title: "Go to http://localhost:12349/html",
-        },
-        {
-          pageAlias: "page",
-          isMainFrame: true,
-          frameUrl: "http://localhost:12349/html",
-          action: {
-            name: "click",
-            selector: "text=Hello world A link to google",
-            signals: [],
-            button: "left",
-            modifiers: 0,
-            clickCount: 1,
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl: "http://localhost:12349/html",
+            action: {
+              name: "click",
+              selector: "text=Hello world A link to google",
+              signals: [],
+              button: "left",
+              modifiers: 0,
+              clickCount: 1,
+            },
+            title: "Click text=Hello world",
           },
-          title: "Click text=Hello world",
-        },
-        {
-          action: {
-            name: "assert",
-            isAssert: true,
-            selector: "text=Hello world",
-            command: "innerText",
-            value: undefined,
-            signals: [],
+          {
+            action: {
+              name: "assert",
+              isAssert: true,
+              selector: "text=Hello world",
+              command: "innerText",
+              value: undefined,
+              signals: [],
+            },
+            frameUrl: "http://localhost:12349/html",
+            modified: false,
+            isMainFrame: true,
+            pageAlias: "page",
           },
-          frameUrl: "http://localhost:12349/html",
-          modified: false,
-          isMainFrame: true,
-          pageAlias: "page",
-        },
-      ],
+        ],
+      },
     ];
 
     it("updates the action at the specified index", () => {
       const updatedSteps = updateAction(steps, "nextValue", 0, 2);
       expect(updatedSteps).toHaveLength(1);
-      expect(updatedSteps[0]).toHaveLength(3);
-      expect(JSON.stringify(updatedSteps[0][0])).toEqual(
-        JSON.stringify(steps[0][0])
+      expect(updatedSteps[0].actions).toHaveLength(3);
+      expect(JSON.stringify(updatedSteps[0].actions[0])).toEqual(
+        JSON.stringify(steps[0].actions[0])
       );
-      expect(JSON.stringify(updatedSteps[0][1])).toEqual(
-        JSON.stringify(steps[0][1])
+      expect(JSON.stringify(updatedSteps[0].actions[1])).toEqual(
+        JSON.stringify(steps[0].actions[1])
       );
-      expect(JSON.stringify(updatedSteps[0][2])).toEqual(
+      expect(JSON.stringify(updatedSteps[0].actions[2])).toEqual(
         JSON.stringify({
-          ...steps[0][2],
-          action: { ...steps[0][2].action, value: "nextValue" },
+          ...steps[0].actions[2],
+          action: { ...steps[0].actions[2].action, value: "nextValue" },
         })
       );
     });
@@ -140,18 +142,20 @@ describe("shared", () => {
     });
 
     it("calls `getCodeFromActions` when a matching step for the failed journey step is found", async () => {
-      const failedStep: Step = [
-        {
-          title: "I failed",
-          action: {
-            name: "click",
-            signals: [],
+      const failedStep: Step = {
+        actions: [
+          {
+            title: "I failed",
+            action: {
+              name: "click",
+              signals: [],
+            },
+            isMainFrame: true,
+            frameUrl: "https://www.elastic.co",
+            pageAlias: "page alias",
           },
-          isMainFrame: true,
-          frameUrl: "https://www.elastic.co",
-          pageAlias: "page alias",
-        },
-      ];
+        ],
+      };
 
       await getCodeForFailedResult(mockIpc, [failedStep], {
         status: "failed",
@@ -167,7 +171,7 @@ describe("shared", () => {
 
       expect(mockIpc.callMain).toHaveBeenCalledTimes(1);
       expect(mockIpc.callMain).toHaveBeenCalledWith("actions-to-code", {
-        actions: failedStep,
+        actions: [failedStep],
         isSuite: false,
       });
     });

--- a/src/common/shared.test.ts
+++ b/src/common/shared.test.ts
@@ -22,9 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+import type { Step, Steps } from "@elastic/synthetics";
 import { RendererProcessIpc } from "electron-better-ipc";
 import { getCodeForFailedResult, updateAction } from "./shared";
-import type { Step, Steps } from "./types";
 
 describe("shared", () => {
   describe("updateAction", () => {

--- a/src/common/shared.ts
+++ b/src/common/shared.ts
@@ -89,7 +89,7 @@ export async function getCodeFromActions(
   type: JourneyType
 ): Promise<string> {
   return await ipc.callMain("actions-to-code", {
-    actions: actions.flat(),
+    actions,
     isSuite: type === "suite",
   });
 }

--- a/src/common/shared.ts
+++ b/src/common/shared.ts
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 import { RendererProcessIpc } from "electron-better-ipc";
 import React from "react";
-import type { Journey, JourneyType, Setter, Steps } from "./types";
+import type { Journey, JourneyType, Setter, Step, Steps } from "./types";
 
 export const COMMAND_SELECTOR_OPTIONS = [
   {
@@ -111,11 +111,15 @@ export function updateAction(
 ): Steps {
   return steps.map((step, sidx) => {
     if (sidx !== stepIndex) return step;
-    return step.map((ac, aidx) => {
-      if (aidx !== actionIndex) return ac;
-      const { action, ...rest } = ac;
-      return { action: { ...action, value }, ...rest };
-    });
+    const nextStep: Step = {
+      actions: step.actions.map((ac, aidx) => {
+        if (aidx !== actionIndex) return ac;
+        const { action, ...rest } = ac;
+        return { action: { ...action, value }, ...rest };
+      }),
+    };
+    if (step.name) nextStep.name = step.name;
+    return nextStep;
   });
 }
 
@@ -139,7 +143,9 @@ export async function getCodeForFailedResult(
   if (!failedJourneyStep) return "";
 
   const failedStep = steps.find(
-    step => step.length > 0 && step[0].title === failedJourneyStep.name
+    step =>
+      step.actions.length > 0 &&
+      step.actions[0].title === failedJourneyStep.name
   );
 
   if (!failedStep) return "";

--- a/src/common/shared.ts
+++ b/src/common/shared.ts
@@ -22,9 +22,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+import type { Step, Steps } from "@elastic/synthetics";
 import { RendererProcessIpc } from "electron-better-ipc";
 import React from "react";
-import type { Journey, JourneyType, Setter, Step, Steps } from "./types";
+import type { Journey, JourneyType, Setter } from "./types";
 
 export const COMMAND_SELECTOR_OPTIONS = [
   {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -24,8 +24,11 @@ THE SOFTWARE.
 
 import { ActionInContext } from "@elastic/synthetics";
 
-export type Step = ActionInContext[];
-export type Steps = ActionInContext[][];
+export interface Step {
+  actions: ActionInContext[];
+  name?: string;
+}
+export type Steps = Step[];
 export type Action = ActionInContext["action"];
 
 export interface Result {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -22,15 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { ActionInContext } from "@elastic/synthetics";
-
-export interface Step {
-  actions: ActionInContext[];
-  name?: string;
-}
-export type Steps = Step[];
-export type Action = ActionInContext["action"];
-
 export interface Result {
   failed: number;
   skipped: number;

--- a/src/components/ActionDetail/ActionDetail.tsx
+++ b/src/components/ActionDetail/ActionDetail.tsx
@@ -67,9 +67,12 @@ export function ActionDetail({
     updatedActionIndex: number
   ) => {
     onStepDetailChange(
-      steps[stepIndex].map((actionToUpdate, index) =>
-        index === updatedActionIndex ? updatedAction : actionToUpdate
-      ),
+      {
+        actions: steps[stepIndex].actions.map((actionToUpdate, index) =>
+          index === updatedActionIndex ? updatedAction : actionToUpdate
+        ),
+        name: steps[stepIndex].name,
+      },
       stepIndex
     );
   };

--- a/src/components/Assertion/Assertion.tsx
+++ b/src/components/Assertion/Assertion.tsx
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { ActionInContext } from "@elastic/synthetics";
+import type { Action, ActionInContext } from "@elastic/synthetics";
 import React, { useContext, useState } from "react";
 import {
   EuiButton,
@@ -33,7 +33,6 @@ import {
   EuiFormRow,
   EuiSpacer,
 } from "@elastic/eui";
-import type { Action } from "../../common/types";
 import { StepsContext } from "../../contexts/StepsContext";
 import { AssertionSelect } from "./Select";
 import { AssertionInfo } from "./AssertionInfo";

--- a/src/components/ExportScriptFlyout/Flyout.tsx
+++ b/src/components/ExportScriptFlyout/Flyout.tsx
@@ -23,9 +23,10 @@ THE SOFTWARE.
 */
 
 import { EuiFlyout } from "@elastic/eui";
+import type { Steps } from "@elastic/synthetics";
 import React, { useContext, useEffect, useMemo, useState } from "react";
 import { getCodeFromActions } from "../../common/shared";
-import type { JourneyType, Setter, Steps } from "../../common/types";
+import type { JourneyType, Setter } from "../../common/types";
 import { CommunicationContext } from "../../contexts/CommunicationContext";
 import { Body } from "./Body";
 import { Footer } from "./Footer";

--- a/src/components/StepList/StepDetails.tsx
+++ b/src/components/StepList/StepDetails.tsx
@@ -46,7 +46,7 @@ interface IStepDetail {
 function StepDetail({ step, stepIndex }: IStepDetail) {
   return (
     <>
-      {step.map((actionContext, index) => (
+      {step.actions.map((actionContext, index) => (
         <ActionDetail
           key={index}
           actionContext={actionContext}
@@ -87,12 +87,15 @@ function StepAccordion({
   const [isEditing, setIsEditing] = useState(false);
   const onStepTitleChange = (updatedTitle: string) => {
     onStepDetailChange(
-      step.map((s, stepIdx) => {
-        if (stepIdx === 0) {
-          return { ...s, title: updatedTitle, modified: true };
-        }
-        return s;
-      }),
+      {
+        actions: step.actions.map((s, stepIdx) => {
+          if (stepIdx === 0) {
+            return { ...s, title: updatedTitle, modified: true };
+          }
+          return s;
+        }),
+        name: step.name,
+      },
       index
     );
   };
@@ -169,7 +172,7 @@ export function StepAccordions({
   return (
     <>
       {steps.map((step, index) => {
-        const { title } = step[0];
+        const { title } = step.actions[0];
         return (
           <StepAccordion
             index={index}

--- a/src/components/StepList/StepDetails.tsx
+++ b/src/components/StepList/StepDetails.tsx
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+import type { Step, Steps } from "@elastic/synthetics";
 import React from "react";
 import { useContext, useState } from "react";
 import {
@@ -36,7 +37,6 @@ import { StepAccordionTitle } from "./StepAccordionTitle";
 import "./StepDetails.css";
 import { RecordingContext } from "../../contexts/RecordingContext";
 import { RecordingStatus } from "../../common/types";
-import type { Step, Steps } from "../../common/types";
 
 interface IStepDetail {
   step: Step;

--- a/src/components/StepSeparator.tsx
+++ b/src/components/StepSeparator.tsx
@@ -61,8 +61,9 @@ interface IStepSeparator {
 }
 
 export function StepSeparator({ index, step }: IStepSeparator) {
+  console.log("step", step);
   const testStatus = useStepResultStatus(
-    step.length ? step[0].title : undefined
+    step.actions.length ? step.actions[0].title : undefined
   );
 
   return (
@@ -79,14 +80,14 @@ export function StepSeparator({ index, step }: IStepSeparator) {
       id={`step-separator-${index}`}
       initialIsOpen
     >
-      {step.map((s, actionIndex) => (
+      {step.actions.map((s, actionIndex) => (
         <ActionElement
           key={`action-${actionIndex}-for-step-${index}`}
           step={s}
           actionIndex={actionIndex}
           stepIndex={index}
           testStatus={testStatus}
-          isLast={actionIndex === step.length - 1}
+          isLast={actionIndex === step.actions.length - 1}
         />
       ))}
     </StepSeparatorAccordion>

--- a/src/components/StepSeparator.tsx
+++ b/src/components/StepSeparator.tsx
@@ -22,11 +22,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+import type { Step } from "@elastic/synthetics";
 import { EuiAccordion, EuiFlexItem, EuiFlexGroup } from "@elastic/eui";
 import React from "react";
 import styled from "styled-components";
 import { SMALL_SCREEN_BREAKPOINT } from "../common/shared";
-import { Step } from "../common/types";
 import { useStepResultStatus } from "../hooks/useTestResult";
 import { ActionElement } from "./ActionElement";
 
@@ -61,7 +61,6 @@ interface IStepSeparator {
 }
 
 export function StepSeparator({ index, step }: IStepSeparator) {
-  console.log("step", step);
   const testStatus = useStepResultStatus(
     step.actions.length ? step.actions[0].title : undefined
   );

--- a/src/contexts/StepsContext.ts
+++ b/src/contexts/StepsContext.ts
@@ -22,9 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import type { ActionInContext } from "@elastic/synthetics";
+import type { ActionInContext, Step, Steps } from "@elastic/synthetics";
 import { createContext } from "react";
-import type { Setter, Step, Steps } from "../common/types";
+import type { Setter } from "../common/types";
 
 function notImplemented() {
   throw Error("Step context not initialized");

--- a/src/helpers/generator.test.ts
+++ b/src/helpers/generator.test.ts
@@ -22,141 +22,730 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { Step } from "../common/types";
-import { generateIR } from "./generator";
-
-const actions: Step = [
-  {
-    pageAlias: "page",
-    isMainFrame: true,
-    frameUrl: "about:blank",
-    committed: true,
-    action: {
-      name: "openPage",
-      url: "about:blank",
-      signals: [],
-    },
-  },
-  {
-    pageAlias: "page",
-    isMainFrame: true,
-    frameUrl: "https://vigneshh.in/",
-    committed: true,
-    action: {
-      name: "navigate",
-      url: "https://vigneshh.in/",
-      signals: [],
-    },
-  },
-  {
-    pageAlias: "page",
-    isMainFrame: true,
-    frameUrl: "https://vigneshh.in/",
-    action: {
-      name: "click",
-      selector: "text=I Enjoy evangelizing the magic of web performance.",
-      signals: [],
-      button: "left",
-      modifiers: 0,
-      clickCount: 1,
-    },
-    committed: true,
-  },
-  {
-    pageAlias: "page",
-    isMainFrame: true,
-    frameUrl: "https://vigneshh.in/",
-    action: {
-      name: "assert",
-      isAssert: true,
-      command: "textContent",
-      selector: "text=Babel Minify",
-      value: "babel",
-      signals: [],
-    },
-  },
-  {
-    pageAlias: "page",
-    isMainFrame: true,
-    frameUrl: "https://vigneshh.in/",
-    action: {
-      name: "click",
-      selector: "text=Babel Minify",
-      signals: [
-        {
-          name: "popup",
-          popupAlias: "page1",
-          isAsync: true,
-        },
-      ],
-      button: "left",
-      modifiers: 0,
-      clickCount: 1,
-    },
-    committed: true,
-  },
-  {
-    pageAlias: "page1",
-    isMainFrame: true,
-    frameUrl: "https://github.com/babel/minify",
-    action: {
-      name: "click",
-      selector: 'a:has-text("smoke")',
-      signals: [
-        {
-          name: "navigation",
-          url: "https://github.com/babel/minify",
-        },
-        {
-          name: "navigation",
-          url: "https://github.com/babel/minify/tree/master/smoke",
-        },
-        {
-          name: "navigation",
-          url: "https://github.com/babel/minify/tree/master/smoke",
-          isAsync: true,
-        },
-        {
-          name: "navigation",
-          url: "https://github.com/babel/minify",
-          isAsync: true,
-        },
-      ],
-      button: "left",
-      modifiers: 0,
-      clickCount: 1,
-    },
-  },
-  {
-    pageAlias: "page1",
-    isMainFrame: true,
-    frameUrl: "https://github.com/babel/minify",
-    committed: true,
-    action: {
-      name: "closePage",
-      signals: [],
-    },
-  },
-  {
-    pageAlias: "page",
-    isMainFrame: true,
-    frameUrl: "https://vigneshh.in/",
-    committed: true,
-    action: {
-      name: "closePage",
-      signals: [],
-    },
-  },
-];
+import { ActionInContext } from "@elastic/synthetics";
+import { Step, Steps } from "../common/types";
+import { generateIR, generateMergedIR } from "./generator";
 
 describe("generator", () => {
   describe("generateIR", () => {
-    it("creates a multi-step IR", () => {
-      const ir = generateIR(actions);
+    let step: Step;
+    beforeEach(() => {
+      step = {
+        actions: [
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl: "about:blank",
+            committed: true,
+            action: {
+              name: "openPage",
+              url: "about:blank",
+              signals: [],
+            },
+          },
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl: "https://vigneshh.in/",
+            committed: true,
+            action: {
+              name: "navigate",
+              url: "https://vigneshh.in/",
+              signals: [],
+            },
+          },
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl: "https://vigneshh.in/",
+            action: {
+              name: "click",
+              selector:
+                "text=I Enjoy evangelizing the magic of web performance.",
+              signals: [],
+              button: "left",
+              modifiers: 0,
+              clickCount: 1,
+            },
+            committed: true,
+          },
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl: "https://vigneshh.in/",
+            action: {
+              name: "assert",
+              isAssert: true,
+              command: "textContent",
+              selector: "text=Babel Minify",
+              value: "babel",
+              signals: [],
+            },
+          },
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl: "https://vigneshh.in/",
+            action: {
+              name: "click",
+              selector: "text=Babel Minify",
+              signals: [
+                {
+                  name: "popup",
+                  popupAlias: "page1",
+                  isAsync: true,
+                },
+              ],
+              button: "left",
+              modifiers: 0,
+              clickCount: 1,
+            },
+            committed: true,
+          },
+          {
+            pageAlias: "page1",
+            isMainFrame: true,
+            frameUrl: "https://github.com/babel/minify",
+            action: {
+              name: "click",
+              selector: 'a:has-text("smoke")',
+              signals: [
+                {
+                  name: "navigation",
+                  url: "https://github.com/babel/minify",
+                },
+                {
+                  name: "navigation",
+                  url: "https://github.com/babel/minify/tree/master/smoke",
+                },
+                {
+                  name: "navigation",
+                  url: "https://github.com/babel/minify/tree/master/smoke",
+                  isAsync: true,
+                },
+                {
+                  name: "navigation",
+                  url: "https://github.com/babel/minify",
+                  isAsync: true,
+                },
+              ],
+              button: "left",
+              modifiers: 0,
+              clickCount: 1,
+            },
+          },
+          {
+            pageAlias: "page1",
+            isMainFrame: true,
+            frameUrl: "https://github.com/babel/minify",
+            committed: true,
+            action: {
+              name: "closePage",
+              signals: [],
+            },
+          },
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl: "https://vigneshh.in/",
+            committed: true,
+            action: {
+              name: "closePage",
+              signals: [],
+            },
+          },
+        ],
+      };
+    });
+    it("creates an enhanced IR", () => {
+      const ir = generateIR([step]);
 
-      expect(ir).toHaveLength(2);
-      expect(ir[0]).toHaveLength(3);
-      expect(ir[1]).toHaveLength(3);
+      expect(ir).toHaveLength(1);
+      expect(ir[0].actions).toHaveLength(8);
+    });
+    it("keeps actions that already have a title", () => {
+      const actionWithTitle = {
+        pageAlias: "page",
+        isMainFrame: true,
+        frameUrl: "https://vigneshh.in/",
+        title: "A custom title",
+        action: {
+          name: "assert",
+          isAssert: true,
+          command: "textContent",
+          selector: "text=Babel Minify",
+          value: "babel",
+          signals: [],
+        },
+      };
+      step.actions.push(actionWithTitle);
+      const ir = generateIR([step]);
+      const { length } = ir[0].actions;
+
+      expect(ir[0].actions[length - 1]).toEqual(actionWithTitle);
+    });
+  });
+  describe("generateMergedIR", () => {
+    const prev: Steps = [
+      {
+        actions: [
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl: "https://news.google.com",
+            committed: true,
+            action: {
+              name: "navigate",
+              url: "https://news.google.com",
+              signals: [],
+            },
+            modified: true,
+            title: "https://news.google.com",
+          },
+        ],
+      },
+      {
+        actions: [
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl: "https://www.google.com/",
+            committed: true,
+            action: {
+              name: "navigate",
+              url: "https://www.google.com/",
+              signals: [],
+            },
+            title: "Go to https://www.google.com/",
+          },
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl: "https://www.google.com/",
+            action: {
+              name: "click",
+              selector: '[aria-label="Search"]',
+              signals: [],
+              button: "left",
+              modifiers: 0,
+              clickCount: 1,
+            },
+            committed: true,
+            title: 'Click [aria-label="Search"]',
+          },
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl: "https://www.google.com/",
+            action: {
+              name: "fill",
+              selector: '[aria-label="Search"]',
+              signals: [],
+              text: "hello world",
+            },
+            committed: true,
+            title: 'Fill [aria-label="Search"]',
+          },
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl: "https://www.google.com/",
+            action: {
+              name: "press",
+              selector: '[aria-label="Search"]',
+              signals: [
+                {
+                  name: "navigation",
+                  url: "https://www.google.com/search?q=hello+world&source=hp&ei=HN8wYuGUN6aD9PwP3ryR2A8&iflsig=AHkkrS4AAAAAYjDtLG_pgIZ4vhlN3VoBrRzhKb2cOf9Y&ved=0ahUKEwjhkrvD48j2AhWmAZ0JHV5eBPsQ4dUDCAk&uact=5&oq=hello+world&gs_lcp=Cgdnd3Mtd2l6EAMyCAgAEIAEELEDMggILhCABBCxAzIICC4QgAQQsQMyCwguEIAEELEDENQCMggIABCABBCxAzIICAAQgAQQsQMyCAgAEIAEELEDMgsILhCABBCxAxDUAjIICAAQgAQQsQMyCAgAEIAEELEDOg4IABCPARDqAhCMAxDlAjoOCC4QjwEQ6gIQjAMQ5QI6DgguEIAEELEDEMcBEKMCOgsIABCABBCxAxCDAToLCC4QgAQQxwEQrwE6CggAELEDEIMBEAo6CAguELEDEIMBOhEILhCABBCxAxCDARDHARCjAjoRCC4QgAQQsQMQgwEQxwEQrwE6BQguEIAEOg4ILhCABBCxAxDHARDRAzoOCC4QgAQQxwEQrwEQ1AI6CwguELEDEMcBEKMCOgUIABCABDoRCC4QgAQQsQMQgwEQxwEQ0QM6CwguEIAEELEDEIMBOgsIABCABBCxAxDJAzoHCAAQsQMQCjoQCC4QgAQQsQMQxwEQ0QMQCjoICAAQgAQQyQM6CAguEIAEENQCUKMEWNYOYPAPaAFwAHgAgAFUiAGcBpIBAjExmAEAoAEBsAEK&sclient=gws-wiz",
+                },
+                {
+                  name: "navigation",
+                  url: "https://www.google.com/search?q=hello+world&source=hp&ei=HN8wYuGUN6aD9PwP3ryR2A8&iflsig=AHkkrS4AAAAAYjDtLG_pgIZ4vhlN3VoBrRzhKb2cOf9Y&ved=0ahUKEwjhkrvD48j2AhWmAZ0JHV5eBPsQ4dUDCAk&uact=5&oq=hello+world&gs_lcp=Cgdnd3Mtd2l6EAMyCAgAEIAEELEDMggILhCABBCxAzIICC4QgAQQsQMyCwguEIAEELEDENQCMggIABCABBCxAzIICAAQgAQQsQMyCAgAEIAEELEDMgsILhCABBCxAxDUAjIICAAQgAQQsQMyCAgAEIAEELEDOg4IABCPARDqAhCMAxDlAjoOCC4QjwEQ6gIQjAMQ5QI6DgguEIAEELEDEMcBEKMCOgsIABCABBCxAxCDAToLCC4QgAQQxwEQrwE6CggAELEDEIMBEAo6CAguELEDEIMBOhEILhCABBCxAxCDARDHARCjAjoRCC4QgAQQsQMQgwEQxwEQrwE6BQguEIAEOg4ILhCABBCxAxDHARDRAzoOCC4QgAQQxwEQrwEQ1AI6CwguELEDEMcBEKMCOgUIABCABDoRCC4QgAQQsQMQgwEQxwEQ0QM6CwguEIAEELEDEIMBOgsIABCABBCxAxDJAzoHCAAQsQMQCjoQCC4QgAQQsQMQxwEQ0QMQCjoICAAQgAQQyQM6CAguEIAEENQCUKMEWNYOYPAPaAFwAHgAgAFUiAGcBpIBAjExmAEAoAEBsAEK&sclient=gws-wiz",
+                  isAsync: true,
+                },
+              ],
+              key: "Enter",
+              modifiers: 0,
+            },
+            committed: true,
+            title: "Press Enter",
+          },
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl:
+              "https://www.google.com/search?q=hello+world&source=hp&ei=HN8wYuGUN6aD9PwP3ryR2A8&iflsig=AHkkrS4AAAAAYjDtLG_pgIZ4vhlN3VoBrRzhKb2cOf9Y&ved=0ahUKEwjhkrvD48j2AhWmAZ0JHV5eBPsQ4dUDCAk&uact=5&oq=hello+world&gs_lcp=Cgdnd3Mtd2l6EAMyCAgAEIAEELEDMggILhCABBCxAzIICC4QgAQQsQMyCwguEIAEELEDENQCMggIABCABBCxAzIICAAQgAQQsQMyCAgAEIAEELEDMgsILhCABBCxAxDUAjIICAAQgAQQsQMyCAgAEIAEELEDOg4IABCPARDqAhCMAxDlAjoOCC4QjwEQ6gIQjAMQ5QI6DgguEIAEELEDEMcBEKMCOgsIABCABBCxAxCDAToLCC4QgAQQxwEQrwE6CggAELEDEIMBEAo6CAguELEDEIMBOhEILhCABBCxAxCDARDHARCjAjoRCC4QgAQQsQMQgwEQxwEQrwE6BQguEIAEOg4ILhCABBCxAxDHARDRAzoOCC4QgAQQxwEQrwEQ1AI6CwguELEDEMcBEKMCOgUIABCABDoRCC4QgAQQsQMQgwEQxwEQ0QM6CwguEIAEELEDEIMBOgsIABCABBCxAxDJAzoHCAAQsQMQCjoQCC4QgAQQsQMQxwEQ0QMQCjoICAAQgAQQyQM6CAguEIAEENQCUKMEWNYOYPAPaAFwAHgAgAFUiAGcBpIBAjExmAEAoAEBsAEK&sclient=gws-wiz",
+            action: {
+              name: "click",
+              selector: 'text=/.*"Hello, World!" program - Wikipedia.*/',
+              signals: [
+                {
+                  name: "navigation",
+                  url: "https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+                },
+              ],
+              button: "left",
+              modifiers: 0,
+              clickCount: 1,
+            },
+            committed: true,
+            title: 'Click text=/.*"Hello, World!" program - Wikipedia.*/',
+          },
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl:
+              "https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+            action: {
+              name: "click",
+              selector: "text=Main page",
+              signals: [
+                {
+                  name: "navigation",
+                  url: "https://en.wikipedia.org/wiki/Main_Page",
+                },
+              ],
+              button: "left",
+              modifiers: 0,
+              clickCount: 1,
+            },
+            committed: true,
+            title: "Click text=Main page",
+          },
+        ],
+      },
+      {
+        actions: [
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl:
+              "https://news.google.com/topstories?hl=en-US&gl=US&ceid=US:en",
+            committed: true,
+            action: {
+              name: "navigate",
+              url: "https://news.google.com/topstories?hl=en-US&gl=US&ceid=US:en",
+              signals: [],
+            },
+            title:
+              "Go to https://news.google.com/topstories?hl=en-US&gl=US&ceid=US:en",
+          },
+        ],
+      },
+    ];
+    const cur: Steps = [
+      {
+        actions: [
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl: "https://www.google.com/?gws_rd=ssl",
+            committed: true,
+            action: {
+              name: "navigate",
+              url: "https://www.google.com/?gws_rd=ssl",
+              signals: [],
+            },
+            title: "Go to https://www.google.com/?gws_rd=ssl",
+          },
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl: "https://www.google.com/",
+            committed: true,
+            action: {
+              name: "navigate",
+              url: "https://www.google.com/",
+              signals: [],
+            },
+            title: "Go to https://www.google.com/",
+          },
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl: "https://www.google.com/",
+            action: {
+              name: "click",
+              selector: '[aria-label="Search"]',
+              signals: [],
+              button: "left",
+              modifiers: 0,
+              clickCount: 1,
+            },
+            committed: true,
+            title: 'Click [aria-label="Search"]',
+          },
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl: "https://www.google.com/",
+            action: {
+              name: "fill",
+              selector: '[aria-label="Search"]',
+              signals: [],
+              text: "hello world",
+            },
+            committed: true,
+            title: 'Fill [aria-label="Search"]',
+          },
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl: "https://www.google.com/",
+            action: {
+              name: "press",
+              selector: '[aria-label="Search"]',
+              signals: [
+                {
+                  name: "navigation",
+                  url: "https://www.google.com/search?q=hello+world&source=hp&ei=HN8wYuGUN6aD9PwP3ryR2A8&iflsig=AHkkrS4AAAAAYjDtLG_pgIZ4vhlN3VoBrRzhKb2cOf9Y&ved=0ahUKEwjhkrvD48j2AhWmAZ0JHV5eBPsQ4dUDCAk&uact=5&oq=hello+world&gs_lcp=Cgdnd3Mtd2l6EAMyCAgAEIAEELEDMggILhCABBCxAzIICC4QgAQQsQMyCwguEIAEELEDENQCMggIABCABBCxAzIICAAQgAQQsQMyCAgAEIAEELEDMgsILhCABBCxAxDUAjIICAAQgAQQsQMyCAgAEIAEELEDOg4IABCPARDqAhCMAxDlAjoOCC4QjwEQ6gIQjAMQ5QI6DgguEIAEELEDEMcBEKMCOgsIABCABBCxAxCDAToLCC4QgAQQxwEQrwE6CggAELEDEIMBEAo6CAguELEDEIMBOhEILhCABBCxAxCDARDHARCjAjoRCC4QgAQQsQMQgwEQxwEQrwE6BQguEIAEOg4ILhCABBCxAxDHARDRAzoOCC4QgAQQxwEQrwEQ1AI6CwguELEDEMcBEKMCOgUIABCABDoRCC4QgAQQsQMQgwEQxwEQ0QM6CwguEIAEELEDEIMBOgsIABCABBCxAxDJAzoHCAAQsQMQCjoQCC4QgAQQsQMQxwEQ0QMQCjoICAAQgAQQyQM6CAguEIAEENQCUKMEWNYOYPAPaAFwAHgAgAFUiAGcBpIBAjExmAEAoAEBsAEK&sclient=gws-wiz",
+                },
+                {
+                  name: "navigation",
+                  url: "https://www.google.com/search?q=hello+world&source=hp&ei=HN8wYuGUN6aD9PwP3ryR2A8&iflsig=AHkkrS4AAAAAYjDtLG_pgIZ4vhlN3VoBrRzhKb2cOf9Y&ved=0ahUKEwjhkrvD48j2AhWmAZ0JHV5eBPsQ4dUDCAk&uact=5&oq=hello+world&gs_lcp=Cgdnd3Mtd2l6EAMyCAgAEIAEELEDMggILhCABBCxAzIICC4QgAQQsQMyCwguEIAEELEDENQCMggIABCABBCxAzIICAAQgAQQsQMyCAgAEIAEELEDMgsILhCABBCxAxDUAjIICAAQgAQQsQMyCAgAEIAEELEDOg4IABCPARDqAhCMAxDlAjoOCC4QjwEQ6gIQjAMQ5QI6DgguEIAEELEDEMcBEKMCOgsIABCABBCxAxCDAToLCC4QgAQQxwEQrwE6CggAELEDEIMBEAo6CAguELEDEIMBOhEILhCABBCxAxCDARDHARCjAjoRCC4QgAQQsQMQgwEQxwEQrwE6BQguEIAEOg4ILhCABBCxAxDHARDRAzoOCC4QgAQQxwEQrwEQ1AI6CwguELEDEMcBEKMCOgUIABCABDoRCC4QgAQQsQMQgwEQxwEQ0QM6CwguEIAEELEDEIMBOgsIABCABBCxAxDJAzoHCAAQsQMQCjoQCC4QgAQQsQMQxwEQ0QMQCjoICAAQgAQQyQM6CAguEIAEENQCUKMEWNYOYPAPaAFwAHgAgAFUiAGcBpIBAjExmAEAoAEBsAEK&sclient=gws-wiz",
+                  isAsync: true,
+                },
+              ],
+              key: "Enter",
+              modifiers: 0,
+            },
+            committed: true,
+            title: "Press Enter",
+          },
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl:
+              "https://www.google.com/search?q=hello+world&source=hp&ei=HN8wYuGUN6aD9PwP3ryR2A8&iflsig=AHkkrS4AAAAAYjDtLG_pgIZ4vhlN3VoBrRzhKb2cOf9Y&ved=0ahUKEwjhkrvD48j2AhWmAZ0JHV5eBPsQ4dUDCAk&uact=5&oq=hello+world&gs_lcp=Cgdnd3Mtd2l6EAMyCAgAEIAEELEDMggILhCABBCxAzIICC4QgAQQsQMyCwguEIAEELEDENQCMggIABCABBCxAzIICAAQgAQQsQMyCAgAEIAEELEDMgsILhCABBCxAxDUAjIICAAQgAQQsQMyCAgAEIAEELEDOg4IABCPARDqAhCMAxDlAjoOCC4QjwEQ6gIQjAMQ5QI6DgguEIAEELEDEMcBEKMCOgsIABCABBCxAxCDAToLCC4QgAQQxwEQrwE6CggAELEDEIMBEAo6CAguELEDEIMBOhEILhCABBCxAxCDARDHARCjAjoRCC4QgAQQsQMQgwEQxwEQrwE6BQguEIAEOg4ILhCABBCxAxDHARDRAzoOCC4QgAQQxwEQrwEQ1AI6CwguELEDEMcBEKMCOgUIABCABDoRCC4QgAQQsQMQgwEQxwEQ0QM6CwguEIAEELEDEIMBOgsIABCABBCxAxDJAzoHCAAQsQMQCjoQCC4QgAQQsQMQxwEQ0QMQCjoICAAQgAQQyQM6CAguEIAEENQCUKMEWNYOYPAPaAFwAHgAgAFUiAGcBpIBAjExmAEAoAEBsAEK&sclient=gws-wiz",
+            action: {
+              name: "click",
+              selector: 'text=/.*"Hello, World!" program - Wikipedia.*/',
+              signals: [
+                {
+                  name: "navigation",
+                  url: "https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+                },
+              ],
+              button: "left",
+              modifiers: 0,
+              clickCount: 1,
+            },
+            committed: true,
+            title: 'Click text=/.*"Hello, World!" program - Wikipedia.*/',
+          },
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl:
+              "https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+            action: {
+              name: "click",
+              selector: "text=Main page",
+              signals: [
+                {
+                  name: "navigation",
+                  url: "https://en.wikipedia.org/wiki/Main_Page",
+                },
+              ],
+              button: "left",
+              modifiers: 0,
+              clickCount: 1,
+            },
+            committed: true,
+            title: "Click text=Main page",
+          },
+          {
+            pageAlias: "page",
+            isMainFrame: true,
+            frameUrl:
+              "https://news.google.com/topstories?hl=en-US&gl=US&ceid=US:en",
+            committed: true,
+            action: {
+              name: "navigate",
+              url: "https://news.google.com/topstories?hl=en-US&gl=US&ceid=US:en",
+              signals: [],
+            },
+            title:
+              "Go to https://news.google.com/topstories?hl=en-US&gl=US&ceid=US:en",
+          },
+        ],
+      },
+    ];
+    it("returns next PW actions if no previous steps", () => {
+      expect(generateMergedIR([], cur)).toEqual(cur);
+    });
+    it("returns empty set if PW actions are empty", () => {
+      expect(generateMergedIR(prev, [])).toEqual([]);
+    });
+    it("picks up assertions", () => {
+      const assert: ActionInContext = {
+        pageAlias: "page",
+        isMainFrame: true,
+        frameUrl: "https://vigneshh.in/",
+        action: {
+          isAssert: true,
+          name: "assert",
+          command: "visible",
+          selector: "text=Babel Minify",
+          signals: [],
+          modifiers: 0,
+          clickCount: 1,
+        },
+        committed: true,
+      };
+      const result = generateMergedIR(
+        [
+          ...prev,
+          {
+            actions: [assert],
+          },
+        ],
+        cur
+      );
+      const r = result[result.length - 1];
+      const { length } = r.actions;
+      expect(r.actions[length - 1]).toEqual(assert);
+    });
+    it("merges updated actions with modified UI actions", () => {
+      expect(generateMergedIR(prev, cur)).toEqual([
+        {
+          actions: [
+            {
+              action: {
+                name: "navigate",
+                signals: [],
+                url: "https://news.google.com",
+              },
+              committed: true,
+              frameUrl: "https://news.google.com",
+              isMainFrame: true,
+              modified: true,
+              pageAlias: "page",
+              title: "https://news.google.com",
+            },
+          ],
+        },
+        {
+          actions: [
+            {
+              action: {
+                name: "navigate",
+                signals: [],
+                url: "https://www.google.com/",
+              },
+              committed: true,
+              frameUrl: "https://www.google.com/",
+              isMainFrame: true,
+              pageAlias: "page",
+              title: "Go to https://www.google.com/",
+            },
+            {
+              action: {
+                button: "left",
+                clickCount: 1,
+                modifiers: 0,
+                name: "click",
+                selector: '[aria-label="Search"]',
+                signals: [],
+              },
+              committed: true,
+              frameUrl: "https://www.google.com/",
+              isMainFrame: true,
+              pageAlias: "page",
+              title: 'Click [aria-label="Search"]',
+            },
+            {
+              action: {
+                name: "fill",
+                selector: '[aria-label="Search"]',
+                signals: [],
+                text: "hello world",
+              },
+              committed: true,
+              frameUrl: "https://www.google.com/",
+              isMainFrame: true,
+              pageAlias: "page",
+              title: 'Fill [aria-label="Search"]',
+            },
+            {
+              action: {
+                key: "Enter",
+                modifiers: 0,
+                name: "press",
+                selector: '[aria-label="Search"]',
+                signals: [
+                  {
+                    name: "navigation",
+                    url: "https://www.google.com/search?q=hello+world&source=hp&ei=HN8wYuGUN6aD9PwP3ryR2A8&iflsig=AHkkrS4AAAAAYjDtLG_pgIZ4vhlN3VoBrRzhKb2cOf9Y&ved=0ahUKEwjhkrvD48j2AhWmAZ0JHV5eBPsQ4dUDCAk&uact=5&oq=hello+world&gs_lcp=Cgdnd3Mtd2l6EAMyCAgAEIAEELEDMggILhCABBCxAzIICC4QgAQQsQMyCwguEIAEELEDENQCMggIABCABBCxAzIICAAQgAQQsQMyCAgAEIAEELEDMgsILhCABBCxAxDUAjIICAAQgAQQsQMyCAgAEIAEELEDOg4IABCPARDqAhCMAxDlAjoOCC4QjwEQ6gIQjAMQ5QI6DgguEIAEELEDEMcBEKMCOgsIABCABBCxAxCDAToLCC4QgAQQxwEQrwE6CggAELEDEIMBEAo6CAguELEDEIMBOhEILhCABBCxAxCDARDHARCjAjoRCC4QgAQQsQMQgwEQxwEQrwE6BQguEIAEOg4ILhCABBCxAxDHARDRAzoOCC4QgAQQxwEQrwEQ1AI6CwguELEDEMcBEKMCOgUIABCABDoRCC4QgAQQsQMQgwEQxwEQ0QM6CwguEIAEELEDEIMBOgsIABCABBCxAxDJAzoHCAAQsQMQCjoQCC4QgAQQsQMQxwEQ0QMQCjoICAAQgAQQyQM6CAguEIAEENQCUKMEWNYOYPAPaAFwAHgAgAFUiAGcBpIBAjExmAEAoAEBsAEK&sclient=gws-wiz",
+                  },
+                  {
+                    isAsync: true,
+                    name: "navigation",
+                    url: "https://www.google.com/search?q=hello+world&source=hp&ei=HN8wYuGUN6aD9PwP3ryR2A8&iflsig=AHkkrS4AAAAAYjDtLG_pgIZ4vhlN3VoBrRzhKb2cOf9Y&ved=0ahUKEwjhkrvD48j2AhWmAZ0JHV5eBPsQ4dUDCAk&uact=5&oq=hello+world&gs_lcp=Cgdnd3Mtd2l6EAMyCAgAEIAEELEDMggILhCABBCxAzIICC4QgAQQsQMyCwguEIAEELEDENQCMggIABCABBCxAzIICAAQgAQQsQMyCAgAEIAEELEDMgsILhCABBCxAxDUAjIICAAQgAQQsQMyCAgAEIAEELEDOg4IABCPARDqAhCMAxDlAjoOCC4QjwEQ6gIQjAMQ5QI6DgguEIAEELEDEMcBEKMCOgsIABCABBCxAxCDAToLCC4QgAQQxwEQrwE6CggAELEDEIMBEAo6CAguELEDEIMBOhEILhCABBCxAxCDARDHARCjAjoRCC4QgAQQsQMQgwEQxwEQrwE6BQguEIAEOg4ILhCABBCxAxDHARDRAzoOCC4QgAQQxwEQrwEQ1AI6CwguELEDEMcBEKMCOgUIABCABDoRCC4QgAQQsQMQgwEQxwEQ0QM6CwguEIAEELEDEIMBOgsIABCABBCxAxDJAzoHCAAQsQMQCjoQCC4QgAQQsQMQxwEQ0QMQCjoICAAQgAQQyQM6CAguEIAEENQCUKMEWNYOYPAPaAFwAHgAgAFUiAGcBpIBAjExmAEAoAEBsAEK&sclient=gws-wiz",
+                  },
+                ],
+              },
+              committed: true,
+              frameUrl: "https://www.google.com/",
+              isMainFrame: true,
+              pageAlias: "page",
+              title: "Press Enter",
+            },
+            {
+              action: {
+                button: "left",
+                clickCount: 1,
+                modifiers: 0,
+                name: "click",
+                selector: 'text=/.*"Hello, World!" program - Wikipedia.*/',
+                signals: [
+                  {
+                    name: "navigation",
+                    url: "https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+                  },
+                ],
+              },
+              committed: true,
+              frameUrl:
+                "https://www.google.com/search?q=hello+world&source=hp&ei=HN8wYuGUN6aD9PwP3ryR2A8&iflsig=AHkkrS4AAAAAYjDtLG_pgIZ4vhlN3VoBrRzhKb2cOf9Y&ved=0ahUKEwjhkrvD48j2AhWmAZ0JHV5eBPsQ4dUDCAk&uact=5&oq=hello+world&gs_lcp=Cgdnd3Mtd2l6EAMyCAgAEIAEELEDMggILhCABBCxAzIICC4QgAQQsQMyCwguEIAEELEDENQCMggIABCABBCxAzIICAAQgAQQsQMyCAgAEIAEELEDMgsILhCABBCxAxDUAjIICAAQgAQQsQMyCAgAEIAEELEDOg4IABCPARDqAhCMAxDlAjoOCC4QjwEQ6gIQjAMQ5QI6DgguEIAEELEDEMcBEKMCOgsIABCABBCxAxCDAToLCC4QgAQQxwEQrwE6CggAELEDEIMBEAo6CAguELEDEIMBOhEILhCABBCxAxCDARDHARCjAjoRCC4QgAQQsQMQgwEQxwEQrwE6BQguEIAEOg4ILhCABBCxAxDHARDRAzoOCC4QgAQQxwEQrwEQ1AI6CwguELEDEMcBEKMCOgUIABCABDoRCC4QgAQQsQMQgwEQxwEQ0QM6CwguEIAEELEDEIMBOgsIABCABBCxAxDJAzoHCAAQsQMQCjoQCC4QgAQQsQMQxwEQ0QMQCjoICAAQgAQQyQM6CAguEIAEENQCUKMEWNYOYPAPaAFwAHgAgAFUiAGcBpIBAjExmAEAoAEBsAEK&sclient=gws-wiz",
+              isMainFrame: true,
+              pageAlias: "page",
+              title: 'Click text=/.*"Hello, World!" program - Wikipedia.*/',
+            },
+            {
+              action: {
+                button: "left",
+                clickCount: 1,
+                modifiers: 0,
+                name: "click",
+                selector: "text=Main page",
+                signals: [
+                  {
+                    name: "navigation",
+                    url: "https://en.wikipedia.org/wiki/Main_Page",
+                  },
+                ],
+              },
+              committed: true,
+              frameUrl:
+                "https://en.wikipedia.org/wiki/%22Hello,_World!%22_program",
+              isMainFrame: true,
+              pageAlias: "page",
+              title: "Click text=Main page",
+            },
+          ],
+        },
+        {
+          actions: [
+            {
+              action: {
+                name: "navigate",
+                signals: [],
+                url: "https://news.google.com/topstories?hl=en-US&gl=US&ceid=US:en",
+              },
+              committed: true,
+              frameUrl:
+                "https://news.google.com/topstories?hl=en-US&gl=US&ceid=US:en",
+              isMainFrame: true,
+              pageAlias: "page",
+              title:
+                "Go to https://news.google.com/topstories?hl=en-US&gl=US&ceid=US:en",
+            },
+          ],
+        },
+      ]);
+    });
+    it("picks up new actions", () => {
+      expect(
+        generateMergedIR(
+          [
+            {
+              actions: [
+                {
+                  action: {
+                    name: "navigate",
+                    signals: [],
+                    url: "https://news.google.com",
+                  },
+                  committed: true,
+                  frameUrl: "https://news.google.com",
+                  isMainFrame: true,
+                  pageAlias: "page",
+                  title:
+                    "Go to https://news.google.com/topstories?hl=en-US&gl=US&ceid=US:en",
+                },
+              ],
+            },
+          ],
+          [
+            {
+              actions: [
+                {
+                  action: {
+                    name: "navigate",
+                    signals: [],
+                    url: "https://news.google.com",
+                  },
+                  committed: true,
+                  frameUrl: "https://news.google.com",
+                  isMainFrame: true,
+                  pageAlias: "page",
+                  title:
+                    "Go to https://news.google.com/topstories?hl=en-US&gl=US&ceid=US:en",
+                },
+                {
+                  pageAlias: "page",
+                  isMainFrame: true,
+                  frameUrl: "https://www.google.com/",
+                  action: {
+                    name: "click",
+                    selector: '[aria-label="Search"]',
+                    signals: [],
+                    button: "left",
+                    modifiers: 0,
+                    clickCount: 1,
+                  },
+                  committed: true,
+                  title: 'Click [aria-label="Search"]',
+                },
+              ],
+            },
+          ]
+        )
+      ).toEqual([
+        {
+          actions: [
+            {
+              action: {
+                name: "navigate",
+                signals: [],
+                url: "https://news.google.com",
+              },
+              committed: true,
+              frameUrl: "https://news.google.com",
+              isMainFrame: true,
+              pageAlias: "page",
+              title:
+                "Go to https://news.google.com/topstories?hl=en-US&gl=US&ceid=US:en",
+            },
+            {
+              pageAlias: "page",
+              isMainFrame: true,
+              frameUrl: "https://www.google.com/",
+              action: {
+                name: "click",
+                selector: '[aria-label="Search"]',
+                signals: [],
+                button: "left",
+                modifiers: 0,
+                clickCount: 1,
+              },
+              committed: true,
+              title: 'Click [aria-label="Search"]',
+            },
+          ],
+        },
+      ]);
     });
   });
 });

--- a/src/helpers/generator.test.ts
+++ b/src/helpers/generator.test.ts
@@ -22,8 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { ActionInContext } from "@elastic/synthetics";
-import { Step, Steps } from "../common/types";
+import type { ActionInContext, Step, Steps } from "@elastic/synthetics";
 import { generateIR, generateMergedIR } from "./generator";
 
 describe("generator", () => {

--- a/src/helpers/generator.ts
+++ b/src/helpers/generator.ts
@@ -22,8 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import type { ActionInContext } from "@elastic/synthetics";
-import type { Action, Step, Steps } from "../common/types";
+import type { Action, ActionInContext, Step, Steps } from "@elastic/synthetics";
 
 export function generateIR(steps: Steps): Steps {
   const result: Steps = [];

--- a/src/helpers/generator.ts
+++ b/src/helpers/generator.ts
@@ -24,6 +24,13 @@ THE SOFTWARE.
 
 import type { Action, ActionInContext, Step, Steps } from "@elastic/synthetics";
 
+/**
+ * Creates an intermediate representation of the steps Playwright has recorded from
+ * user interaction. Each step contains a list of actions to nest in the corresponding
+ * test function, and a set of metadata such as `name`.
+ * @param steps The steps to format into the custom IR
+ * @returns Formatted steps
+ */
 export function generateIR(steps: Steps): Steps {
   const result: Steps = [];
   const actions: ActionInContext[] = [];

--- a/src/helpers/generator.ts
+++ b/src/helpers/generator.ts
@@ -25,49 +25,23 @@ THE SOFTWARE.
 import type { ActionInContext } from "@elastic/synthetics";
 import type { Action, Step, Steps } from "../common/types";
 
-export function generateIR(actionContexts: Step) {
-  const result = [];
-  let steps = [];
-  let previousContext = null;
-  let newStep = false;
-  for (const actionContext of actionContexts) {
-    const { action, pageAlias, title } = actionContext;
-    if (action.name === "openPage") {
-      continue;
-    } else if (action.name === "closePage" && pageAlias === "page") {
-      continue;
+export function generateIR(steps: Steps): Steps {
+  const result: Steps = [];
+  const actions: ActionInContext[] = [];
+  for (const step of steps) {
+    for (const actionContext of step.actions) {
+      const { action, title } = actionContext;
+      // Add title to all actionContexts
+      actions.push(
+        title ? actionContext : { ...actionContext, title: actionTitle(action) }
+      );
     }
+    if (actions.length > 0) {
+      result.push({ actions, name: step.name });
+    }
+  }
 
-    newStep = isNewStep(actionContext, previousContext);
-    if (newStep && steps.length > 0) {
-      result.push(steps);
-      steps = [];
-    }
-    // Add title to all actionContexts
-    const enhancedContext = title
-      ? actionContext
-      : { ...actionContext, title: actionTitle(action) };
-    steps.push(enhancedContext);
-    previousContext = actionContext;
-  }
-  if (steps.length > 0) {
-    result.push(steps);
-  }
   return result;
-}
-
-function isNewStep(
-  actionContext: ActionInContext,
-  previousContext: ActionInContext | null
-) {
-  const { action, frameUrl } = actionContext;
-
-  if (action.name === "navigate") {
-    return true;
-  } else if (action.name === "click") {
-    return previousContext?.frameUrl === frameUrl && action.signals.length > 0;
-  }
-  return false;
 }
 
 export function actionTitle(
@@ -106,48 +80,58 @@ export function actionTitle(
   }
 }
 
+const getActionCount = (prev: number, cur: Step) => prev + cur.actions.length;
+
 /**
  * Works by taking the actions from the PW recorder and
  * the actions generated/modified by the UI and merges them
  * to display the correct modified actions on the UI
  */
-export function generateMergedIR(prevSteps: Steps, currSteps: Steps): Steps {
-  const prevActionContexts = prevSteps.flat();
-  const currActionContexts = currSteps.flat();
-  const prevLength = prevActionContexts.length;
-  const currLength = currActionContexts.length;
+export function generateMergedIR(prevSteps: Steps, nextSteps: Steps): Steps {
+  const prevLength = prevSteps.reduce(getActionCount, 0);
+  const nextLength = nextSteps.reduce(getActionCount, 0);
   /**
    * when recorder is started/resetted
    */
-  if (currLength === 0 || prevLength === 0) {
-    return currSteps;
+  if (prevLength === 0 || nextLength === 0) {
+    return nextSteps;
   }
 
-  const mergedActions = [];
-  const maxLen = Math.max(prevLength, currLength);
-  for (let i = 0, j = 0; i < maxLen || j < maxLen; i++, j++) {
-    /**
-     * Keep adding all the assertions added by user as PW
-     * does not have any assertion built in
-     * We treat the UI as the source of truth
-     */
-    if (prevActionContexts[i]?.action.name === "assert") {
-      do {
-        mergedActions.push(prevActionContexts[i]);
-        i++;
-      } while (i < maxLen && prevActionContexts[i]?.action.name === "assert");
+  const mergedSteps: Steps = [];
+  let pwActionCount = 0;
+  for (const step of prevSteps) {
+    const actions: ActionInContext[] = [];
+    for (const action of step.actions) {
+      if (action.action.name === "assert") {
+        /**
+         * Keep adding all the assertions added by user as PW
+         * does not have any assertion built in
+         * We treat the UI as the source of truth
+         */
+        actions.push(action);
+      } else {
+        /**
+         * If actions are not assert commands, then we need to
+         * check if the actions are modified on the UI and add
+         * them to the final list
+         *
+         * Any modified state in the UI is the final state
+         */
+        const item = action?.modified
+          ? action
+          : nextSteps[0].actions[pwActionCount];
+        actions.push(item);
+        pwActionCount++;
+      }
     }
-    /**
-     * If actions are not assert commands, then we need to
-     * check if the actions are modified on the UI and add
-     * them to the final list
-     *
-     * Any modified state in the UI is the final state
-     */
-    const item = prevActionContexts[i]?.modified
-      ? prevActionContexts[i]
-      : currActionContexts[j];
-    item && mergedActions.push(item);
+    mergedSteps.push({ actions });
   }
-  return generateIR(mergedActions);
+  /**
+   * Append any new Playwright actions to the final step
+   */
+  const lastStep = mergedSteps[mergedSteps.length - 1];
+  nextSteps[0].actions
+    .filter((_, index) => index >= pwActionCount)
+    .map(action => lastStep.actions.push(action));
+  return mergedSteps;
 }

--- a/src/hooks/useStepsContext.test.ts
+++ b/src/hooks/useStepsContext.test.ts
@@ -53,8 +53,10 @@ describe("useStepsContext", () => {
 
   beforeEach(async () => {
     defaultSteps = [
-      [createAction("first-step-1")],
-      [createAction("first-step-2"), createAction("second-step-2")],
+      { actions: [createAction("first-step-1")] },
+      {
+        actions: [createAction("first-step-2"), createAction("second-step-2")],
+      },
     ];
 
     defaultResult = renderHook(() => useStepsContext());
@@ -66,7 +68,7 @@ describe("useStepsContext", () => {
 
   describe("onStepDetailChange", () => {
     it("updates the targeted step", () => {
-      const testStep: Step = [createAction("new-action")];
+      const testStep: Step = { actions: [createAction("new-action")] };
 
       act(() => {
         defaultResult.result.current.onStepDetailChange(testStep, 1);
@@ -74,7 +76,7 @@ describe("useStepsContext", () => {
 
       const { steps } = defaultResult.result.current;
 
-      expect(steps[0]).toEqual(defaultSteps[0]);
+      expect(steps[0].actions).toEqual(defaultSteps[0].actions);
       expect(steps[1]).toEqual(testStep);
       expect(steps).toHaveLength(2);
     });
@@ -90,8 +92,8 @@ describe("useStepsContext", () => {
 
       expect(steps).toHaveLength(2);
       expect(steps[0]).toEqual(defaultSteps[0]);
-      expect(steps[1]).toHaveLength(1);
-      expect(steps[1][0]).toEqual(defaultSteps[1][0]);
+      expect(steps[1].actions).toHaveLength(1);
+      expect(steps[1].actions[0]).toEqual(defaultSteps[1].actions[0]);
     });
   });
 
@@ -120,8 +122,8 @@ describe("useStepsContext", () => {
 
       expect(steps).toHaveLength(2);
       expect(steps[0]).toEqual(defaultSteps[0]);
-      expect(steps[1]).toHaveLength(3);
-      expect(steps[1][2]).toEqual(insertedAction);
+      expect(steps[1].actions).toHaveLength(3);
+      expect(steps[1].actions[2]).toEqual(insertedAction);
     });
   });
 
@@ -136,18 +138,24 @@ describe("useStepsContext", () => {
       const { steps } = defaultResult.result.current;
 
       expect(steps).toHaveLength(2);
-      expect(steps[0]).toHaveLength(1);
-      expect(steps[1]).toHaveLength(2);
-      expect(steps[0][0]).toEqual(updatedAction);
+      expect(steps[0].actions).toHaveLength(1);
+      expect(steps[1].actions).toHaveLength(2);
+      expect(steps[0].actions[0]).toEqual(updatedAction);
       expect(steps[1]).toEqual(defaultSteps[1]);
     });
   });
 
   describe("onMergeSteps", () => {
-    const mergeSteps = [
-      [createAction("first-step-1")],
-      [createAction("second-step-1")],
-      [createAction("third-step-1")],
+    const mergeSteps: Steps = [
+      {
+        actions: [createAction("first-step-1")],
+      },
+      {
+        actions: [createAction("second-step-1")],
+      },
+      {
+        actions: [createAction("third-step-1")],
+      },
     ];
 
     it("merges two steps and inserts them at the first index", () => {
@@ -160,21 +168,22 @@ describe("useStepsContext", () => {
       });
       const { steps } = result.current;
       expect(steps).toHaveLength(2);
-      expect(steps[0]).toEqual([
-        createAction("first-step-1"),
-        createAction("second-step-1"),
-      ]);
-      expect(steps[1]).toEqual([
-        {
-          action: {
-            name: "third-step-1",
-            signals: [],
+      expect(steps[0]).toEqual({
+        actions: [createAction("first-step-1"), createAction("second-step-1")],
+      });
+      expect(steps[1]).toEqual({
+        actions: [
+          {
+            action: {
+              name: "third-step-1",
+              signals: [],
+            },
+            frameUrl: "https://www.elastic.co",
+            isMainFrame: true,
+            pageAlias: "pageAlias",
           },
-          frameUrl: "https://www.elastic.co",
-          isMainFrame: true,
-          pageAlias: "pageAlias",
-        },
-      ]);
+        ],
+      });
     });
   });
 
@@ -187,26 +196,28 @@ describe("useStepsContext", () => {
       const { steps } = defaultResult.result.current;
 
       expect(steps).toHaveLength(2);
-      expect(steps[0]).toHaveLength(2);
-      expect(steps[0].map(({ action: { name } }) => name)).toEqual([
+      expect(steps[0].actions).toHaveLength(2);
+      expect(steps[0].actions.map(({ action: { name } }) => name)).toEqual([
         "first-step-2",
         "second-step-2",
       ]);
-      expect(steps[1]).toHaveLength(1);
-      expect(steps[1][0].action.name).toBe("first-step-1");
+      expect(steps[1].actions).toHaveLength(1);
+      expect(steps[1].actions[0].action.name).toBe("first-step-1");
     });
   });
 
   describe("onSplitStep", () => {
-    const splitSteps = [
-      [createAction("first-step-1"), createAction("first-step-2")],
-      [
-        createAction("second-step-1"),
-        createAction("second-step-2"),
-        createAction("second-step-3"),
-        createAction("second-step-4"),
-      ],
-      [createAction("third-step-1"), createAction("third-step-2")],
+    const splitSteps: Steps = [
+      { actions: [createAction("first-step-1"), createAction("first-step-2")] },
+      {
+        actions: [
+          createAction("second-step-1"),
+          createAction("second-step-2"),
+          createAction("second-step-3"),
+          createAction("second-step-4"),
+        ],
+      },
+      { actions: [createAction("third-step-1"), createAction("third-step-2")] },
     ];
 
     it("throws error when `actionIndex` is 0", () => {
@@ -220,7 +231,7 @@ describe("useStepsContext", () => {
       const { result } = renderHook(() => useStepsContext());
 
       act(() => {
-        result.current.setSteps([[createAction("name")]]);
+        result.current.setSteps([{ actions: [createAction("name")] }]);
       });
 
       expect(() => result.current.onSplitStep(0, 1)).toThrowError(
@@ -240,8 +251,8 @@ describe("useStepsContext", () => {
 
       const { steps } = result.result.current;
       expect(steps).toHaveLength(4);
-      expect(steps[0]).toEqual([createAction("first-step-1")]);
-      expect(steps[1]).toEqual([createAction("first-step-2")]);
+      expect(steps[0].actions).toEqual([createAction("first-step-1")]);
+      expect(steps[1].actions).toEqual([createAction("first-step-2")]);
     });
     it("splits the target step at the tail of the list", () => {
       const result = renderHook(() => useStepsContext());
@@ -255,8 +266,8 @@ describe("useStepsContext", () => {
 
       const { steps } = result.result.current;
       expect(steps).toHaveLength(4);
-      expect(steps[2]).toEqual([createAction("third-step-1")]);
-      expect(steps[3]).toEqual([createAction("third-step-2")]);
+      expect(steps[2].actions).toEqual([createAction("third-step-1")]);
+      expect(steps[3].actions).toEqual([createAction("third-step-2")]);
     });
 
     it("throws an error if the step index is greater than the steps list length", () => {
@@ -283,19 +294,19 @@ describe("useStepsContext", () => {
       });
       const { steps } = result.result.current;
       expect(steps).toHaveLength(4);
-      expect(steps[0]).toEqual([
+      expect(steps[0].actions).toEqual([
         createAction("first-step-1"),
         createAction("first-step-2"),
       ]);
-      expect(steps[1]).toEqual([
+      expect(steps[1].actions).toEqual([
         createAction("second-step-1"),
         createAction("second-step-2"),
       ]);
-      expect(steps[2]).toEqual([
+      expect(steps[2].actions).toEqual([
         createAction("second-step-3"),
         createAction("second-step-4"),
       ]);
-      expect(steps[3]).toEqual([
+      expect(steps[3].actions).toEqual([
         createAction("third-step-1"),
         createAction("third-step-2"),
       ]);

--- a/src/hooks/useStepsContext.test.ts
+++ b/src/hooks/useStepsContext.test.ts
@@ -21,13 +21,12 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-import { ActionInContext } from "@elastic/synthetics";
+import type { ActionInContext, Step, Steps } from "@elastic/synthetics";
 import {
   act,
   renderHook,
   RenderHookResult,
 } from "@testing-library/react-hooks";
-import type { Step, Steps } from "../common/types";
 import { IStepsContext } from "../contexts/StepsContext";
 import { useStepsContext } from "./useStepsContext";
 

--- a/src/hooks/useStepsContext.ts
+++ b/src/hooks/useStepsContext.ts
@@ -45,9 +45,9 @@ export function useStepsContext(): IStepsContext {
         steps.map((step, currentStepIndex) => {
           if (currentStepIndex !== targetStepIdx) return step;
 
-          step.splice(indexToDelete, 1);
+          step.actions.splice(indexToDelete, 1);
 
-          return [...step];
+          return { ...step, actions: [...step.actions] };
         })
       );
     },
@@ -59,18 +59,24 @@ export function useStepsContext(): IStepsContext {
         steps.map((step, currentStepIndex) => {
           if (currentStepIndex !== targetStepIdx) return step;
 
-          step.splice(indexToInsert, 0, action);
+          step.actions.splice(indexToInsert, 0, action);
 
-          return [...step];
+          return { name: step.name, actions: [...step.actions] };
         })
       );
     },
     onMergeSteps: (indexToInsert, indexToRemove) => {
       setSteps(oldSteps => {
-        oldSteps[indexToInsert] = [
-          ...steps[indexToInsert],
-          ...steps[indexToRemove],
-        ];
+        oldSteps[indexToInsert] = {
+          name:
+            oldSteps[indexToInsert].name ??
+            oldSteps[indexToRemove].name ??
+            undefined,
+          actions: [
+            ...steps[indexToInsert].actions,
+            ...steps[indexToRemove].actions,
+          ],
+        };
         oldSteps.splice(indexToRemove, 1);
         return oldSteps;
       });
@@ -91,16 +97,16 @@ export function useStepsContext(): IStepsContext {
         throw Error("Step index cannot exceed steps length.");
       }
       const stepToSplit = steps[stepIndex];
-      if (stepToSplit.length <= 1) {
+      if (stepToSplit.actions.length <= 1) {
         throw Error("Cannot split step with only one action.");
       }
-      const reducedStep = stepToSplit.slice(0, actionIndex);
-      const insertedStep = stepToSplit.slice(actionIndex);
+      const reducedStepActions = stepToSplit.actions.slice(0, actionIndex);
+      const insertedStepActions = stepToSplit.actions.slice(actionIndex);
 
       setSteps([
         ...steps.slice(0, stepIndex),
-        reducedStep,
-        insertedStep,
+        { name: stepToSplit.name, actions: reducedStepActions },
+        { actions: insertedStepActions },
         ...steps.slice(stepIndex + 1, steps.length),
       ]);
     },
@@ -112,11 +118,14 @@ export function useStepsContext(): IStepsContext {
     ) => {
       const step = steps[stepIndex];
       onStepDetailChange(
-        [
-          ...step.slice(0, actionIndex),
-          action,
-          ...step.slice(actionIndex + 1, step.length),
-        ],
+        {
+          actions: [
+            ...step.actions.slice(0, actionIndex),
+            action,
+            ...step.actions.slice(actionIndex + 1, step.actions.length),
+          ],
+          name: step.name,
+        },
         stepIndex
       );
     },

--- a/src/hooks/useStepsContext.ts
+++ b/src/hooks/useStepsContext.ts
@@ -22,9 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { ActionInContext } from "@elastic/synthetics";
+import type { ActionInContext, Step, Steps } from "@elastic/synthetics";
 import { useState } from "react";
-import type { Step, Steps } from "../common/types";
 import type { IStepsContext } from "../contexts/StepsContext";
 
 export function useStepsContext(): IStepsContext {

--- a/src/hooks/useSyntheticsTest.ts
+++ b/src/hooks/useSyntheticsTest.ts
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+import type { Steps } from "@elastic/synthetics";
 import { IpcRendererEvent } from "electron";
 import {
   useCallback,
@@ -31,7 +32,7 @@ import {
   useState,
 } from "react";
 import { getCodeFromActions, getCodeForFailedResult } from "../common/shared";
-import { Result, Steps, TestEvent } from "../common/types";
+import { Result, TestEvent } from "../common/types";
 import { ITestContext } from "../contexts/TestContext";
 import { CommunicationContext } from "../contexts/CommunicationContext";
 import { resultReducer } from "../helpers/resultReducer";


### PR DESCRIPTION
## Summary

Resolves #169.

Depends on https://github.com/elastic/synthetics/pull/457 + a new release of Synthetics.

This change goes alongside a patch to Synthetics.

This change would switch the `Steps` type from `Array<ActionInContext[]>` to `Array<{ actions: ActionInContext[]; name?: string}>`; This allows us to natively support custom fields at the step level, whereas today we're using nested `Array`s and have less flexibility when it comes to fixing state to the individual steps.

This change also would move the `Step` and `Steps` types to Synthetics to avoid circular references for some recorder-specific functionality I added that allows us to pass these objects cleanly to synthetics and preserve the steps the user will create/modify after they're done recording.

## Implementation details

This branch relies on https://github.com/elastic/synthetics/pull/457, we will be unable to merge this change without that PR being merged and released.

## How to validate this change

To run this code, you'd need to:
- in Synthetics, pull down https://github.com/elastic/synthetics/pull/457, run `npm run build && npm pack`
- in the recorder repo's `package.json`: update the `@elastic/synthetics` dependency value to be `file:{RELATIVE_PATH_TO_SYNTHETICS}/elastic-synthetics-1.0.0-beta.22.tgz`. If the version of Synthetics is bumped after this writing, you might need to update the version number.
- in the recorder repo: `rm -rf node_modules && npm install`. Then you can run `npm run dev` like normal.