### PR TITLE
fix: Update EUI version and switch to Amsterdam

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1651,6 +1651,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@base2/pretty-print-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@base2/pretty-print-object/-/pretty-print-object-1.0.1.tgz",
+      "integrity": "sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA=="
+    },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -1705,9 +1710,9 @@
       }
     },
     "@elastic/eui": {
-      "version": "48.0.0",
-      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-48.0.0.tgz",
-      "integrity": "sha512-L9IJmd0oFWxgSA/ETMEagFuqS8MQMQJmI3WzH2xCPOOZGAZH6YxbNMoM7ocK+usdRKRALaZAmESK90mVOLOMpg==",
+      "version": "52.1.0",
+      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-52.1.0.tgz",
+      "integrity": "sha512-nkCnpYxYcotwxi1aodFgUSKrjX0EB8NLwNQhpomCT5Gm4UekwQJlD7D/dTaI/koc/ISLKFNo6ZNNETPHMQn6Ng==",
       "requires": {
         "@types/chroma-js": "^2.0.0",
         "@types/lodash": "^4.14.160",
@@ -1727,6 +1732,7 @@
         "prop-types": "^15.6.0",
         "react-beautiful-dnd": "^13.1.0",
         "react-dropzone": "^11.5.3",
+        "react-element-to-jsx-string": "^14.3.4",
         "react-focus-on": "^3.5.4",
         "react-input-autosize": "^3.0.0",
         "react-is": "^17.0.2",
@@ -1744,7 +1750,7 @@
         "text-diff": "^1.0.1",
         "unified": "^9.2.0",
         "unist-util-visit": "^2.0.3",
-        "url-parse": "^1.5.3",
+        "url-parse": "^1.5.10",
         "uuid": "^8.3.0",
         "vfile": "^4.2.0"
       }
@@ -3540,9 +3546,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.178",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
-      "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw=="
+      "version": "4.14.180",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.180.tgz",
+      "integrity": "sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g=="
     },
     "@types/mdast": {
       "version": "3.0.10",
@@ -3688,9 +3694,9 @@
       }
     },
     "@types/react-redux": {
-      "version": "7.1.22",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.22.tgz",
-      "integrity": "sha512-GxIA1kM7ClU73I6wg9IRTVwSO9GS+SAKZKe0Enj+82HMU6aoESFU2HNAdNi3+J53IaOHPiUfT3kSG4L828joDQ==",
+      "version": "7.1.23",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.23.tgz",
+      "integrity": "sha512-D02o3FPfqQlfu2WeEYwh3x2otYd2Dk1o8wAfsA0B1C2AJEFxE663Ozu7JzuWbznGgW248NaOF6wsqCGNq9d3qw==",
       "requires": {
         "@types/hoist-non-react-statics": "^3.3.0",
         "@types/react": "*",
@@ -15203,9 +15209,9 @@
       }
     },
     "prismjs": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.25.0.tgz",
-      "integrity": "sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg=="
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA=="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -15614,6 +15620,23 @@
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
+    "react-element-to-jsx-string": {
+      "version": "14.3.4",
+      "resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-14.3.4.tgz",
+      "integrity": "sha512-t4ZwvV6vwNxzujDQ+37bspnLwA4JlgUPWhLjBJWsNIDceAf6ZKUTCjdm08cN6WeZ5pTMKiCJkmAYnpmR4Bm+dg==",
+      "requires": {
+        "@base2/pretty-print-object": "1.0.1",
+        "is-plain-object": "5.0.0",
+        "react-is": "17.0.2"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
         }
       }
     },
@@ -16834,13 +16857,13 @@
       }
     },
     "refractor": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.5.0.tgz",
-      "integrity": "sha512-QwPJd3ferTZ4cSPPjdP5bsYHMytwWYnAN5EEnLtGvkqp/FCCnGsBgxrm9EuIDnjUC3Uc/kETtvVi7fSIVC74Dg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
+      "integrity": "sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==",
       "requires": {
         "hastscript": "^6.0.0",
         "parse-entities": "^2.0.0",
-        "prismjs": "~1.25.0"
+        "prismjs": "~1.27.0"
       }
     },
     "regenerate": {
@@ -17029,6 +17052,13 @@
         "unist-util-remove-position": "^2.0.0",
         "vfile-location": "^3.0.0",
         "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "trim": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+          "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+        }
       }
     },
     "remark-rehype": {
@@ -19155,11 +19185,6 @@
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
-    },
     "trim-trailing-lines": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz",
@@ -19451,9 +19476,9 @@
       }
     },
     "unist-util-stringify-position": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.0.tgz",
-      "integrity": "sha512-SdfAl8fsDclywZpfMDTVDxA2V7LjtRDTOFd44wUJamgl6OlVngsqWjxvermMYf60elWHbxhuRCZml7AnuXCaSA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+      "integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
       "requires": {
         "@types/unist": "^2.0.0"
       }
@@ -19596,9 +19621,9 @@
       "dev": true
     },
     "url-parse": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.6.tgz",
-      "integrity": "sha512-xj3QdUJ1DttD1LeSfvJlU1eiF1RvBSBfUu8GplFGdUzSO28y5yUtEl7wb//PI4Af6qh0o/K8545vUmucRrfWsw==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -19781,9 +19806,9 @@
       "integrity": "sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA=="
     },
     "vfile-message": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.0.tgz",
-      "integrity": "sha512-4QJbBk+DkPEhBXq3f260xSaWtjE4gPKOfulzfMFF8ZNwaPZieWsg3iVlcmF04+eebzpcpeXOOFMfrYzJHVYg+g==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+      "integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "@elastic/datemath": "^5.0.3",
     "@elastic/eui": "^52.1.0",
     "@elastic/synthetics": "=1.0.0-beta.19",
+    "@emotion/cache": "^11.7.1",
     "@emotion/react": "^11.7.1",
     "dotenv": "^10.0.0",
     "electron-better-ipc": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
-    "@elastic/eui": "^48.0.0",
+    "@elastic/eui": "^52.1.0",
     "@elastic/synthetics": "=1.0.0-beta.19",
     "@emotion/react": "^11.7.1",
     "dotenv": "^10.0.0",

--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta name="global-style-insert" />
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.png" />
     <meta

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ THE SOFTWARE.
 import React, { useContext } from "react";
 import { useEffect, useState } from "react";
 import { EuiCode, EuiEmptyPrompt, EuiProvider } from "@elastic/eui";
+import createCache from "@emotion/cache";
 import "./App.css";
 import "@elastic/eui/dist/eui_theme_light.css";
 import { Title } from "./components/Header/Title";
@@ -39,7 +40,6 @@ import { useSyntheticsTest } from "./hooks/useSyntheticsTest";
 import { generateIR, generateMergedIR } from "./helpers/generator";
 import { StepSeparator } from "./components/StepSeparator";
 
-import "@elastic/eui/dist/eui_theme_light.json";
 import "./App.css";
 import { useStepsContext } from "./hooks/useStepsContext";
 import { TestResult } from "./components/TestResult";
@@ -48,6 +48,13 @@ import { StyledComponentsEuiProvider } from "./contexts/StyledComponentsEuiProvi
 import { ExportScriptFlyout } from "./components/ExportScriptFlyout";
 import { useRecordingContext } from "./hooks/useRecordingContext";
 import { StartOverWarningModal } from "./components/StartOverWarningModal";
+
+const cache = createCache({
+  key: "elastic-synthetics-recorder",
+  container:
+    document.querySelector<HTMLElement>('meta[name="global-style-insert"]') ??
+    undefined,
+});
 
 export default function App() {
   const [url, setUrl] = useState("");
@@ -77,7 +84,7 @@ export default function App() {
   }, [ipc, setSteps]);
 
   return (
-    <EuiProvider colorMode="light">
+    <EuiProvider cache={cache} colorMode="light">
       <StyledComponentsEuiProvider>
         <StepsContext.Provider value={stepsContextUtils}>
           <RecordingContext.Provider value={recordingContextUtils}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,14 +24,9 @@ THE SOFTWARE.
 
 import React, { useContext } from "react";
 import { useEffect, useState } from "react";
-import {
-  EuiCode,
-  EuiEmptyPrompt,
-  EuiThemeProvider,
-  EuiThemeAmsterdam,
-} from "@elastic/eui";
+import { EuiCode, EuiEmptyPrompt, EuiProvider } from "@elastic/eui";
 import "./App.css";
-import "@elastic/eui/dist/eui_legacy_light.css";
+import "@elastic/eui/dist/eui_theme_light.css";
 import { Title } from "./components/Header/Title";
 import { HeaderControls } from "./components/Header/HeaderControls";
 import { CommunicationContext } from "./contexts/CommunicationContext";
@@ -82,7 +77,7 @@ export default function App() {
   }, [ipc, setSteps]);
 
   return (
-    <EuiThemeProvider theme={EuiThemeAmsterdam}>
+    <EuiProvider colorMode="light">
       <StyledComponentsEuiProvider>
         <StepsContext.Provider value={stepsContextUtils}>
           <RecordingContext.Provider value={recordingContextUtils}>
@@ -133,6 +128,6 @@ export default function App() {
           </RecordingContext.Provider>
         </StepsContext.Provider>
       </StyledComponentsEuiProvider>
-    </EuiThemeProvider>
+    </EuiProvider>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,11 @@ import { ExportScriptFlyout } from "./components/ExportScriptFlyout";
 import { useRecordingContext } from "./hooks/useRecordingContext";
 import { StartOverWarningModal } from "./components/StartOverWarningModal";
 
+/**
+ * This is the prescribed workaround to some internal EUI issues that occur
+ * when EUI component styles load before the global styles. For more information, see
+ * https://elastic.github.io/eui/#/utilities/provider#global-styles.
+ */
 const cache = createCache({
   key: "elastic-synthetics-recorder",
   container:

--- a/src/components/TestResult/ResultFlyoutItem.tsx
+++ b/src/components/TestResult/ResultFlyoutItem.tsx
@@ -31,17 +31,11 @@ import { ResultTitle } from "./ResultTitle";
 
 export interface IResultFlyoutItem {
   code: string;
-  key: string;
   step: JourneyStep;
   stepIndex: number;
 }
 
-export function ResultFlyoutItem({
-  code,
-  key,
-  step,
-  stepIndex,
-}: IResultFlyoutItem) {
+export function ResultFlyoutItem({ code, step, stepIndex }: IResultFlyoutItem) {
   const { actionTitles, status, error, duration } = step;
 
   const durationElement = (
@@ -51,7 +45,6 @@ export function ResultFlyoutItem({
   return (
     <ResultTitle
       durationElement={durationElement}
-      key={key}
       titleText={`Step ${stepIndex + 1}`}
     >
       {error ? (

--- a/src/components/TestResult/ResultTitle.tsx
+++ b/src/components/TestResult/ResultTitle.tsx
@@ -28,18 +28,16 @@ import { Bold, ResultContainer, ResultHeader } from "./styles";
 
 export interface IResultHeader {
   durationElement: JSX.Element;
-  key?: string;
   titleText: string;
 }
 
 export const ResultTitle: React.FC<IResultHeader> = ({
   children,
   durationElement,
-  key,
   titleText,
 }) => {
   return (
-    <ResultContainer key={key} hasShadow={false}>
+    <ResultContainer hasShadow={false}>
       <ResultHeader>
         <EuiFlexGroup>
           <EuiFlexItem>

--- a/src/components/TestResult/styles.tsx
+++ b/src/components/TestResult/styles.tsx
@@ -39,6 +39,7 @@ export const ResultContainer = styled(EuiPanel)`
   }
   padding: 0px;
   margin: 0px 0px 24px 0px;
+  border: ${props => props.theme.border.thin};
 `;
 
 export const ResultHeader = styled.h3`

--- a/src/contexts/StyledComponentsEuiProvider.tsx
+++ b/src/contexts/StyledComponentsEuiProvider.tsx
@@ -22,11 +22,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { EuiThemeContext } from "@elastic/eui";
-import React, { useContext } from "react";
+import { useEuiTheme } from "@elastic/eui";
+import React from "react";
 import { ThemeProvider } from "styled-components";
 
 export const StyledComponentsEuiProvider: React.FC = ({ children }) => {
-  const euiTheme = useContext(EuiThemeContext);
+  const { euiTheme } = useEuiTheme();
   return <ThemeProvider theme={euiTheme}>{children}</ThemeProvider>;
 };


### PR DESCRIPTION
## Summary

Resolves #167.

As noted in the linked issue, we aren't using the latest and greatest EUI theme. Fixing that here.

## Implementation details

There may be minor things that break and are tough to notice. It might be worthwhile to build a binary from `main` and compare it against this branch in dev mode.

## How to validate this change

There should be no functional change with this patch, it should update EUI and utilize the Amsterdam styles.