### PR TITLE
fix: URL input expands for longer value

### DIFF
--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -72,15 +72,12 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
     startTest();
   }, [setIsTestInProgress, setResult, startTest]);
 
-  const SHOULD_USE_FULL_WIDTH = url.length > 60;
-  const SHOULD_RECORDING_CONTROLS_GROW = !SHOULD_USE_FULL_WIDTH;
-
   return (
     <Header alignItems="center" gutterSize="m">
       {recordingStatus === RecordingStatus.NotRecording && (
         <EuiFlexItem>
           <UrlField
-            fullWidth={SHOULD_USE_FULL_WIDTH}
+            fullWidth
             recordingStatus={recordingStatus}
             setUrl={setUrl}
             toggleRecording={toggleRecording}
@@ -113,7 +110,6 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
             isDisabled={recordingStatus !== RecordingStatus.Recording}
             color="primary"
             iconType="stop"
-            isDisabled={recordingStatus !== RecordingStatus.Recording}
             onClick={() => {
               toggleRecording();
             }}
@@ -122,7 +118,7 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
           </ControlButton>
         </EuiFlexItem>
       )}
-      <EuiFlexItem grow={SHOULD_RECORDING_CONTROLS_GROW}>
+      <EuiFlexItem grow={false}>
         <RecordingStatusIndicator status={recordingStatus} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>

--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -77,7 +77,6 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
       {recordingStatus === RecordingStatus.NotRecording && (
         <EuiFlexItem>
           <UrlField
-            fullWidth
             recordingStatus={recordingStatus}
             setUrl={setUrl}
             toggleRecording={toggleRecording}

--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -77,6 +77,7 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
       {recordingStatus === RecordingStatus.NotRecording && (
         <EuiFlexItem>
           <UrlField
+            fullWidth={url.length > 60}
             recordingStatus={recordingStatus}
             setUrl={setUrl}
             toggleRecording={toggleRecording}
@@ -105,10 +106,11 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
       {recordingStatus !== RecordingStatus.NotRecording && (
         <EuiFlexItem grow={false}>
           <ControlButton
-            aria-label="Stop"
+            aria-label="Stop recording and clear all recorded actions"
             isDisabled={recordingStatus !== RecordingStatus.Recording}
             color="primary"
             iconType="stop"
+            isDisabled={recordingStatus !== RecordingStatus.Recording}
             onClick={() => {
               toggleRecording();
             }}
@@ -117,7 +119,7 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
           </ControlButton>
         </EuiFlexItem>
       )}
-      <EuiFlexItem>
+      <EuiFlexItem grow={url.length < 60}>
         <RecordingStatusIndicator status={recordingStatus} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>

--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -72,12 +72,15 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
     startTest();
   }, [setIsTestInProgress, setResult, startTest]);
 
+  const SHOULD_USE_FULL_WIDTH = url.length > 60;
+  const SHOULD_RECORDING_CONTROLS_GROW = !SHOULD_USE_FULL_WIDTH;
+
   return (
     <Header alignItems="center" gutterSize="m">
       {recordingStatus === RecordingStatus.NotRecording && (
         <EuiFlexItem>
           <UrlField
-            fullWidth={url.length > 60}
+            fullWidth={SHOULD_USE_FULL_WIDTH}
             recordingStatus={recordingStatus}
             setUrl={setUrl}
             toggleRecording={toggleRecording}
@@ -119,7 +122,7 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
           </ControlButton>
         </EuiFlexItem>
       )}
-      <EuiFlexItem grow={url.length < 60}>
+      <EuiFlexItem grow={SHOULD_RECORDING_CONTROLS_GROW}>
         <RecordingStatusIndicator status={recordingStatus} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>

--- a/src/components/Header/UrlField.tsx
+++ b/src/components/Header/UrlField.tsx
@@ -28,6 +28,7 @@ import type { Setter } from "../../common/types";
 import { RecordingStatus } from "../../common/types";
 
 export interface IUrlField {
+  fullWidth?: boolean;
   recordingStatus: RecordingStatus;
   setUrl: Setter<string>;
   toggleRecording: () => void;
@@ -38,6 +39,7 @@ export const URL_FIELD_LABEL =
   "Set the starting point for your synthetic journey";
 
 export function UrlField({
+  fullWidth,
   recordingStatus,
   setUrl,
   toggleRecording,
@@ -46,6 +48,7 @@ export function UrlField({
   return (
     <EuiFieldText
       aria-label={URL_FIELD_LABEL}
+      fullWidth={fullWidth}
       onChange={e => {
         setUrl(e.target.value);
       }}

--- a/src/components/Header/UrlField.tsx
+++ b/src/components/Header/UrlField.tsx
@@ -28,7 +28,6 @@ import type { Setter } from "../../common/types";
 import { RecordingStatus } from "../../common/types";
 
 export interface IUrlField {
-  fullWidth?: boolean;
   recordingStatus: RecordingStatus;
   setUrl: Setter<string>;
   toggleRecording: () => void;
@@ -39,7 +38,6 @@ export const URL_FIELD_LABEL =
   "Set the starting point for your synthetic journey";
 
 export function UrlField({
-  fullWidth,
   recordingStatus,
   setUrl,
   toggleRecording,
@@ -48,7 +46,7 @@ export function UrlField({
   return (
     <EuiFieldText
       aria-label={URL_FIELD_LABEL}
-      fullWidth={fullWidth}
+      fullWidth
       onChange={e => {
         setUrl(e.target.value);
       }}


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/synthetics-recorder/issues/161.

## Implementation details

Previously the URL input would not expand to fill available space. This PR makes the input maintain its original size, unless the user begins to enter an excessively long URL. In that case, the input field will expand to the bounds of the parent element.

Additionally, the `grow` prop for the recording controls is now dependent on the URL. It will `grow` for small URLs, but to maximize space usage it will stop `grow`ing so the URL field can fill the entirety of the available whitespace in the header controls area.

## How to validate this change

Check that a smaller URL value results in the field staying small.

Check that a larger URL results in the field filling the available space in the header control section.