### PR TITLE
fix: Make assertions expanded on init

### DIFF
--- a/src/components/ActionElement/ActionElement.tsx
+++ b/src/components/ActionElement/ActionElement.tsx
@@ -65,12 +65,13 @@ function ActionComponent({
   stepIndex,
   testStatus,
 }: IActionElement) {
+  const isAssertion = step.action.isAssert;
   const { onDeleteAction } = useContext(StepsContext);
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(isAssertion ?? false);
   const [areControlsVisible, setAreControlsVisible] = useState(false);
   const close = () => setIsOpen(false);
 
-  const actionUI = step.action.isAssert ? (
+  const actionUI = isAssertion ? (
     <Assertion
       action={step.action}
       actionContext={step}


### PR DESCRIPTION
## Summary

Resolves #162.

Assertions are expanded when created.

## Implementation details

I've updated the inline state management for assertion elements to start out as expanded.


## How to validate this change

1. Record some actions
1. Add an assertion after one of your actions
1. Observe that the assertion you added is expanded when created