### PR TITLE
ci: release tag based (stage 1)

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
     }
     stage('Install'){
       options { skipDefaultCheckout() }
-      when { expression { return !isTag() }
+      when { expression { return !isTag() } }
       steps {
         withGithubNotify(context: "Install") {
           withNodeJSEnv() {
@@ -53,7 +53,7 @@ pipeline {
     }
     stage('Lint'){
       options { skipDefaultCheckout() }
-      when { expression { return !isTag() }
+      when { expression { return !isTag() } }
       steps {
         withGithubNotify(context: "Lint") {
           withNodeJSEnv() {
@@ -72,7 +72,7 @@ pipeline {
     }
     stage('Docker test setup') {
       options { skipDefaultCheckout() }
-      when { expression { return !isTag() }
+      when { expression { return !isTag() } }
       agent {
         dockerfile {
           reuseNode true

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -11,6 +11,9 @@ pipeline {
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     PIPELINE_LOG_LEVEL = "INFO"
     DISPLAY= ":99"
+    RELEASE_URL_MESSAGE = "(<https://github.com/elastic/${env.REPO}/releases/tag/${env.TAG_NAME}|${env.TAG_NAME}>)"
+    SLACK_CHANNEL = '#TBD'
+    NOTIFY_TO = 'TBD+release@elastic.co'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -27,6 +30,7 @@ pipeline {
   }
   stages {
     stage('Checkout') {
+      options { skipDefaultCheckout() }
       steps {
         pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
@@ -35,6 +39,8 @@ pipeline {
       }
     }
     stage('Install'){
+      options { skipDefaultCheckout() }
+      when { not { return isTag() } }
       steps {
         withGithubNotify(context: "Install") {
           withNodeJSEnv() {
@@ -46,6 +52,8 @@ pipeline {
       }
     }
     stage('Lint'){
+      options { skipDefaultCheckout() }
+      when { not { return isTag() } }
       steps {
         withGithubNotify(context: "Lint") {
           withNodeJSEnv() {
@@ -63,6 +71,8 @@ pipeline {
       }
     }
     stage('Docker test setup') {
+      options { skipDefaultCheckout() }
+      when { not { return isTag() } }
       agent {
         dockerfile {
           reuseNode true
@@ -83,6 +93,7 @@ pipeline {
       }
     }
     stage('Build'){
+      options { skipDefaultCheckout() }
       steps {
         withGithubNotify(context: "Build") {
           withNodeJSEnv() {
@@ -93,10 +104,55 @@ pipeline {
         }
       }
     }
+    stage('Release') {
+      options { skipDefaultCheckout() }
+      when {
+        beforeAgent true
+        tag pattern: 'v\\d+\\.\\d+.*', comparator: 'REGEXP'
+      }
+      stages {
+        stage('Dist') {
+          steps {
+            echo 'TBD'
+          }
+        }
+        stage('Release Notes') {
+          steps {
+            withGhEnv(forceInstallation: true, version: '2.4.0') {
+              dir("${BASE_DIR}"){
+                cmd(label: 'make release-notes', script: 'make -C .ci release-notes')
+              }
+            }
+          }
+        }
+      }
+      post {
+        success {
+          whenTrue(isTag()) {
+            notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release *${env.TAG_NAME}* published", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)")
+          }
+        }
+        failure {
+          whenTrue(isTag()) {
+            notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release *${env.TAG_NAME}* could not be published.", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)")
+          }
+        }
+      }
+    }
   }
   post {
     cleanup {
       notifyBuildResult(prComment: true)
     }
   }
+}
+
+
+def notifyStatus(def args = [:]) {
+  releaseNotification(slackChannel: "${env.SLACK_CHANNEL}",
+                      slackColor: args.slackStatus,
+                      slackCredentialsId: 'jenkins-slack-integration-token',
+                      to: "${env.NOTIFY_TO}",
+                      subject: args.subject,
+                      body: args.body)
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -128,14 +128,10 @@ pipeline {
       }
       post {
         success {
-          whenTrue(isTag()) {
-            notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release *${env.TAG_NAME}* published", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)")
-          }
+          notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release *${env.TAG_NAME}* published", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)")
         }
         failure {
-          whenTrue(isTag()) {
-            notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release *${env.TAG_NAME}* could not be published.", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)")
-          }
+          notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release *${env.TAG_NAME}* could not be published.", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)")
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
     }
     stage('Install'){
       options { skipDefaultCheckout() }
-      when { not { return isTag() } }
+      when { expression { return !isTag() }
       steps {
         withGithubNotify(context: "Install") {
           withNodeJSEnv() {
@@ -53,7 +53,7 @@ pipeline {
     }
     stage('Lint'){
       options { skipDefaultCheckout() }
-      when { not { return isTag() } }
+      when { expression { return !isTag() }
       steps {
         withGithubNotify(context: "Lint") {
           withNodeJSEnv() {
@@ -72,7 +72,7 @@ pipeline {
     }
     stage('Docker test setup') {
       options { skipDefaultCheckout() }
-      when { not { return isTag() } }
+      when { expression { return !isTag() }
       agent {
         dockerfile {
           reuseNode true

--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -1,0 +1,15 @@
+SHELL = /bin/bash -eo pipefail
+
+release-notes: validate-branch-name
+	@gh release list
+	@gh \
+		release \
+		create $(BRANCH_NAME) \
+		--title '$(BRANCH_NAME)' \
+    --draft \
+    --generate-notes
+
+validate-branch-name:
+ifndef BRANCH_NAME
+	$(error BRANCH_NAME is undefined)
+endif


### PR DESCRIPTION
## Summary

Automate the release and publishing steps.

## Implementation details

* Tag based event (`v<major>.<minor>.*`)
* Notify if something bad happened
* Create draft release
* Skip all the stages but build and release when a tag release is created, every commit is validated in the CI either coming from a PR or merged to the main branch or release branches, therefore there is no need to validate it again when a tag is created from a validated commit.

## Next steps

* Package and upload the artifacts as assets to the GitHub release
* Sign the artifacts

## Requirements
* Confirm what slack/email to be used for notifications.