### PR TITLE
fix: Fill defect for `ControlButton`

### DIFF
--- a/src/components/ControlButton.tsx
+++ b/src/components/ControlButton.tsx
@@ -68,7 +68,7 @@ export const ControlButton: React.FC<Props> = props => {
 
   return (
     <EuiToolTip content={tooltipContent} delay="long">
-      <EuiButton fill {...rest} />
+      <EuiButton fill={fill} {...rest} />
     </EuiToolTip>
   );
 };


### PR DESCRIPTION
## Summary

As part of #179 I merged a defect that caused a fill to be applied to all instances of `ControlButton`. This patch fixes it to restore the intended functionality.

### Before
<img width="1098" alt="image" src="https://user-images.githubusercontent.com/18429259/160882408-2692a55e-ed65-4d16-a67e-e06de383c151.png">

### After
<img width="1100" alt="image" src="https://user-images.githubusercontent.com/18429259/160882572-20bbd77f-e19a-4dc0-8525-760e78f9a5f1.png">


## Implementation details

Changes the `fill` prop to be conditional again.

## How to validate this change

Make sure that not all of the buttons have `fill`s.