### PR TITLE
feat: Add hotkey/menu item to open new window when 0 windows open on macOS

### DIFF
--- a/electron/electron.ts
+++ b/electron/electron.ts
@@ -73,8 +73,14 @@ async function createWindow() {
   return mainWindowEmitter;
 }
 
+async function initMainWindow() {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createWindow();
+  }
+}
+
 function createMenu() {
-  const menuTemplate = buildMenu(app.name);
+  const menuTemplate = buildMenu(app.name, initMainWindow);
   Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));
 }
 

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 import type { MenuItemConstructorOptions } from 'electron';
 
-export function buildMenu(appName: string): MenuItemConstructorOptions[] {
+export function buildMenu(appName: string, initMain: () => void): MenuItemConstructorOptions[] {
   return [
     {
       label: appName,
@@ -60,6 +60,11 @@ export function buildMenu(appName: string): MenuItemConstructorOptions[] {
     {
       role: 'window',
       submenu: [
+        {
+          label: 'New Main Window',
+          accelerator: 'CommandOrControl+N',
+          click: initMain,
+        },
         { role: 'close' },
         { role: 'minimize' },
         { role: 'zoom' },


### PR DESCRIPTION
## Summary

Resolves #14.

Adds the ability to open a new window with the hotkey `CMD/CTRL+N`, intended for the macOS behavior where the application has 0 open windows but continues to run.

This UX differs from other platforms, but since it will only run when there are 0 windows open (and therefore the process should have already terminated), I didn't think we needed to add OS-specific checks.

The inspiration for this mirrors other electron applications like Slack or VS Code; when all of their windows are closed and the app is focused, `CMD+N` triggers a re-opening of the app with a fresh window.

## Implementation details

This is WIP for the reasons explained below:

One way this could improve is to disable the menu option when there is `> 1 window` available. This might entail rebuilding the menu when certain handlers fire on the electron side, but in my initial investigations I couldn't resolve this quickly. It's probably worth doing to ensure we're maximizing the UX value here. We might also want to consider a different hotkey as we may want to use `CMD+N` for something different in the future.

## How to validate this change

- Run the recorder on macOS. Close the recorder window with `CMD+W`, or by use of the mouse. Send `CMD+N` and see that a new window appears.
- Do this again, but use the menu in the OS's top bar and see it also reopens the window.
- Ensure that this functionality does nothing when a window is already open.