### PR TITLE
fix: Header layout when paused

### DIFF
--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -110,7 +110,12 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
           </ControlButton>
         </EuiFlexItem>
       )}
-      <EuiFlexItem grow={recordingStatus === RecordingStatus.Recording}>
+      <EuiFlexItem
+        grow={
+          recordingStatus === RecordingStatus.Recording ||
+          recordingStatus === RecordingStatus.Paused
+        }
+      >
         <RecordingStatusIndicator status={recordingStatus} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>


### PR DESCRIPTION
## Summary

Resolves #202.

Fixes header layout when Paused.

## Implementation details

One-line change.

## How to validate this change

### Before

<img width="1091" alt="image" src="https://user-images.githubusercontent.com/18429259/163442679-5f0f85da-5ede-4259-bc32-a012eda790d9.png">


### After

<img width="1100" alt="image" src="https://user-images.githubusercontent.com/18429259/163442623-2f46c077-36d2-437d-81dd-326a4b14ffeb.png">
