### PR TITLE
fix: Make Test button disabled during recording/paused states

### DIFF
--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -120,7 +120,7 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
               isDisabled={
                 isTestInProgress ||
                 steps.length === 0 ||
-                recordingStatus === RecordingStatus.Recording
+                recordingStatus !== RecordingStatus.NotRecording
               }
               showTooltip={steps.length === 0}
               onTest={onTest}


### PR DESCRIPTION
## Summary

Resolves #203.

Make the `Test` button disabled during recording/paused states.

## Implementation details

One-line change.

## How to validate this change

### Before

<img width="711" alt="image" src="https://user-images.githubusercontent.com/18429259/163444023-fee835f4-e3a9-408d-ba78-534bedee523d.png">

### After

<img width="702" alt="image" src="https://user-images.githubusercontent.com/18429259/163443989-5f18dd7f-00ab-4beb-bdbd-2972372f5e3a.png">

