### PR TITLE
fix: Reset default values when action/assertion edit view closes

### DIFF
--- a/e2e/tests/assertionInfo.test.ts
+++ b/e2e/tests/assertionInfo.test.ts
@@ -41,9 +41,6 @@ describe('Assertion Info Popover', () => {
       'id=action-element-0-0',
       'text=Add assertion'
     );
-    await electronWindow.click('id=action-element-0-1');
-    await electronWindow.hover('id=action-element-0-1');
-    await electronWindow.click(`[aria-label="Begin editing this action"] >> nth=1`);
     await electronWindow.click(
       `[aria-label="Shows a popover with more information about Playwright assertions."]`
     );

--- a/src/components/ActionElement/ActionElement.tsx
+++ b/src/components/ActionElement/ActionElement.tsx
@@ -152,7 +152,7 @@ function ActionComponent({
             />
           }
         >
-          {!actionContext.action.isAssert && (
+          {!actionContext.action.isAssert && actionContext.isOpen && (
             <ActionDetail
               actionContext={actionContext}
               actionIndex={actionIndex}
@@ -160,7 +160,7 @@ function ActionComponent({
               stepIndex={stepIndex}
             />
           )}
-          {actionContext.action.isAssert && (
+          {actionContext.action.isAssert && actionContext.isOpen && (
             <Assertion
               actionIndex={actionIndex}
               actionContext={actionContext}


### PR DESCRIPTION
## Summary

Resolves #201.

## Implementation details

Conditionally renders the child for `ActionElement`, which will cause all local state to be destroyed when the element is closed.

The side effect of this change is that the default values for the edit forms will reset between close/open events.


## How to validate this change

Open an assertion and an action element, modify some values in the forms, then close and reopen the elements. Your ephemeral changes should be lost.