### PR TITLE
fix: use action.url instead of frameUrl in header

### DIFF
--- a/e2e/tests/actionValues.test.ts
+++ b/e2e/tests/actionValues.test.ts
@@ -54,7 +54,7 @@ async function editAssertion(electronWindow: Page) {
   await electronWindow.fill(`[aria-label="Assertion selector"]`, ASSERTION_SELECTOR);
   await electronWindow.fill(`[aria-label="Assertion value"]`, ASSERTION_VALUE);
   await electronWindow.click(`[data-test-subj="save-0-1"]`);
-  // make sure state has been updated by checking the ation header's content
+  // make sure state has been updated by checking the action header's content
   await electronWindow.waitForSelector(`#action-element-0-1 >> div:has-text("Inner Text")`, {
     timeout: 2000,
   });

--- a/e2e/tests/actionValues.test.ts
+++ b/e2e/tests/actionValues.test.ts
@@ -54,6 +54,10 @@ async function editAssertion(electronWindow: Page) {
   await electronWindow.fill(`[aria-label="Assertion selector"]`, ASSERTION_SELECTOR);
   await electronWindow.fill(`[aria-label="Assertion value"]`, ASSERTION_VALUE);
   await electronWindow.click(`[data-test-subj="save-0-1"]`);
+  // make sure state has been updated by checking the ation header's content
+  await electronWindow.waitForSelector(`#action-element-0-1 >> div:has-text("Inner Text")`, {
+    timeout: 2000,
+  });
 }
 
 async function editAction(electronWindow: Page) {
@@ -63,6 +67,10 @@ async function editAction(electronWindow: Page) {
   );
   await electronWindow.fill(`[data-test-subj="edit-url-0-0"]`, ACTION_URL);
   await electronWindow.click(`[data-test-subj="save-action-0-0"]`);
+  // make sure state has been updated by checking the ation header's content
+  await electronWindow.waitForSelector(`id=action-element-0-0 >> div:has-text("${ACTION_URL}")`, {
+    timeout: 2000,
+  });
 }
 
 describe('Assertion and Action values', () => {

--- a/src/components/ActionElement/HeadingText.tsx
+++ b/src/components/ActionElement/HeadingText.tsx
@@ -47,7 +47,7 @@ export function HeadingText({ actionContext }: IHeadingText) {
       <WrapText>
         &nbsp;
         {actionContext.action.name !== 'navigate' && actionContext.action.selector}
-        {actionContext.action.name === 'navigate' ? actionContext.frameUrl : null}
+        {actionContext.action.name === 'navigate' ? actionContext.action.url : null}
       </WrapText>
     </EuiFlexGroup>
   );


### PR DESCRIPTION
fixes #210 
(possibly fixes #200)

## Summary

<!-- What does this change do? Which issue does it solve? -->
It shows the correct URL in Action header after updating the url value
<!-- If you have any screenshots or GIFs, here's where you should include them. -->
[![Image from Gyazo](https://i.gyazo.com/7f3be4677f83ef4f38f8df152deffa98.gif)](https://gyazo.com/7f3be4677f83ef4f38f8df152deffa98)
## Implementation details
Use actionInContext.action.url instead of actionInContext.frameUrl

## How to validate this change
Update url in navigate action and notice that the url in action header is also updated to the correct value
Also the test will expect for the element header to contain the new value
