### PR TITLE
feat: Send toast on successful file save

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,30 +23,32 @@ THE SOFTWARE.
 */
 import React, { useContext } from 'react';
 import { useEffect, useState } from 'react';
-import { EuiCode, EuiEmptyPrompt, EuiProvider } from '@elastic/eui';
+import { EuiCode, EuiEmptyPrompt, EuiGlobalToastList, EuiProvider } from '@elastic/eui';
 import type { Steps } from '@elastic/synthetics';
 import createCache from '@emotion/cache';
 import '@elastic/eui/dist/eui_theme_light.css';
 import { Title } from './components/Header/Title';
 import { HeaderControls } from './components/Header/HeaderControls';
 import { CommunicationContext } from './contexts/CommunicationContext';
+import { DragAndDropContext } from './contexts/DragAndDropContext';
 import { RecordingContext } from './contexts/RecordingContext';
 import { UrlContext } from './contexts/UrlContext';
 import { StepsContext } from './contexts/StepsContext';
 import { TestContext } from './contexts/TestContext';
+import { ToastContext } from './contexts/ToastContext';
+import { useDragAndDropContext } from './hooks/useDragAndDropContext';
+import { useGlobalToasts } from './hooks/useGlobalToasts';
+import { useStepsContext } from './hooks/useStepsContext';
 import { useSyntheticsTest } from './hooks/useSyntheticsTest';
 import { generateIR, generateMergedIR } from './helpers/generator';
 import { StepSeparator } from './components/StepSeparator';
 
-import { useStepsContext } from './hooks/useStepsContext';
 import { TestResult } from './components/TestResult';
 import { AppPageBody } from './components/AppPageBody';
 import { StyledComponentsEuiProvider } from './contexts/StyledComponentsEuiProvider';
 import { ExportScriptFlyout } from './components/ExportScriptFlyout';
 import { useRecordingContext } from './hooks/useRecordingContext';
 import { StartOverWarningModal } from './components/StartOverWarningModal';
-import { DragAndDropContext } from './contexts/DragAndDropContext';
-import { useDragAndDropContext } from './hooks/useDragAndDropContext';
 import { ActionContext } from './common/types';
 
 /**
@@ -76,6 +78,9 @@ export default function App() {
   const { isStartOverModalVisible, setIsStartOverModalVisible, startOver } = recordingContextUtils;
   const dragAndDropContext = useDragAndDropContext();
 
+  const { dismissToast, sendToast, setToastLifeTimeMs, toasts, toastLifeTimeMs } =
+    useGlobalToasts();
+
   useEffect(() => {
     // `actions` here is a set of `ActionInContext`s that make up a `Step`
     const listener = ({ actions }: { actions: ActionContext[] }) => {
@@ -98,40 +103,49 @@ export default function App() {
             <TestContext.Provider value={syntheticsTestUtils}>
               <UrlContext.Provider value={{ url, setUrl }}>
                 <DragAndDropContext.Provider value={dragAndDropContext}>
-                  <Title />
-                  <HeaderControls setIsCodeFlyoutVisible={setIsCodeFlyoutVisible} />
-                  <AppPageBody>
-                    {steps.length === 0 && (
-                      <EuiEmptyPrompt
-                        hasBorder={false}
-                        title={<h3>No steps recorded yet</h3>}
-                        body={
-                          <p>
-                            Click on <EuiCode>Start recording</EuiCode> to get started with your
-                            script.
-                          </p>
-                        }
-                      />
-                    )}
-                    {steps.map((step, index) => (
-                      <StepSeparator
-                        index={index}
-                        key={`step-separator-${index + 1}`}
-                        step={step}
-                      />
-                    ))}
-                    <TestResult />
-                    {isCodeFlyoutVisible && (
-                      <ExportScriptFlyout setVisible={setIsCodeFlyoutVisible} steps={steps} />
-                    )}
-                    {isStartOverModalVisible && (
-                      <StartOverWarningModal
-                        startOver={startOver}
-                        setVisibility={setIsStartOverModalVisible}
-                        stepCount={steps.length}
-                      />
-                    )}
-                  </AppPageBody>
+                  <ToastContext.Provider
+                    value={{ dismissToast, sendToast, setToastLifeTimeMs, toasts, toastLifeTimeMs }}
+                  >
+                    <Title />
+                    <HeaderControls setIsCodeFlyoutVisible={setIsCodeFlyoutVisible} />
+                    <AppPageBody>
+                      {steps.length === 0 && (
+                        <EuiEmptyPrompt
+                          hasBorder={false}
+                          title={<h3>No steps recorded yet</h3>}
+                          body={
+                            <p>
+                              Click on <EuiCode>Start recording</EuiCode> to get started with your
+                              script.
+                            </p>
+                          }
+                        />
+                      )}
+                      {steps.map((step, index) => (
+                        <StepSeparator
+                          index={index}
+                          key={`step-separator-${index + 1}`}
+                          step={step}
+                        />
+                      ))}
+                      <TestResult />
+                      {isCodeFlyoutVisible && (
+                        <ExportScriptFlyout setVisible={setIsCodeFlyoutVisible} steps={steps} />
+                      )}
+                      {isStartOverModalVisible && (
+                        <StartOverWarningModal
+                          startOver={startOver}
+                          setVisibility={setIsStartOverModalVisible}
+                          stepCount={steps.length}
+                        />
+                      )}
+                    </AppPageBody>
+                    <EuiGlobalToastList
+                      toasts={toasts}
+                      dismissToast={dismissToast}
+                      toastLifeTimeMs={toastLifeTimeMs}
+                    />
+                  </ToastContext.Provider>
                 </DragAndDropContext.Provider>
               </UrlContext.Provider>
             </TestContext.Provider>

--- a/src/components/SaveCodeButton.tsx
+++ b/src/components/SaveCodeButton.tsx
@@ -28,6 +28,7 @@ import { getCodeFromActions } from '../common/shared';
 import type { JourneyType } from '../common/types';
 import { CommunicationContext } from '../contexts/CommunicationContext';
 import { StepsContext } from '../contexts/StepsContext';
+import { ToastContext } from '../contexts/ToastContext';
 
 interface ISaveCodeButton {
   type: JourneyType;
@@ -36,9 +37,14 @@ interface ISaveCodeButton {
 export function SaveCodeButton({ type }: ISaveCodeButton) {
   const { ipc } = useContext(CommunicationContext);
   const { steps } = useContext(StepsContext);
+  const { sendToast } = useContext(ToastContext);
   const onSave = async () => {
     const codeFromActions = await getCodeFromActions(ipc, steps, type);
     await ipc.callMain('save-file', codeFromActions);
+    sendToast({
+      id: `file-export-${new Date().valueOf()}`,
+      title: 'Script export successful',
+    });
   };
   return (
     <EuiButton fill color="primary" iconType="exportAction" onClick={onSave}>

--- a/src/components/SaveCodeButton.tsx
+++ b/src/components/SaveCodeButton.tsx
@@ -44,6 +44,7 @@ export function SaveCodeButton({ type }: ISaveCodeButton) {
     sendToast({
       id: `file-export-${new Date().valueOf()}`,
       title: 'Script export successful',
+      color: 'success',
     });
   };
   return (

--- a/src/contexts/ToastContext.ts
+++ b/src/contexts/ToastContext.ts
@@ -34,14 +34,14 @@ export interface IToastContext {
   setToastLifeTimeMs: Setter<number>;
 }
 
-function notImplemented() {
-  throw Error('not implemented');
+function notInitialized() {
+  throw Error('not initialized');
 }
 
 export const ToastContext = createContext<IToastContext>({
-  dismissToast: notImplemented,
-  sendToast: notImplemented,
-  setToastLifeTimeMs: notImplemented,
+  dismissToast: notInitialized,
+  sendToast: notInitialized,
+  setToastLifeTimeMs: notInitialized,
   toasts: [],
   toastLifeTimeMs: -1,
 });

--- a/src/contexts/ToastContext.ts
+++ b/src/contexts/ToastContext.ts
@@ -1,0 +1,47 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
+import { createContext } from 'react';
+import { Setter } from '../common/types';
+
+export interface IToastContext {
+  sendToast: (toast: Toast) => void;
+  dismissToast: (toast: Toast) => void;
+  toasts: Toast[];
+  toastLifeTimeMs: number;
+  setToastLifeTimeMs: Setter<number>;
+}
+
+function notImplemented() {
+  throw Error('not implemented');
+}
+
+export const ToastContext = createContext<IToastContext>({
+  dismissToast: notImplemented,
+  sendToast: notImplemented,
+  setToastLifeTimeMs: notImplemented,
+  toasts: [],
+  toastLifeTimeMs: -1,
+});

--- a/src/hooks/useGlobalToasts.ts
+++ b/src/hooks/useGlobalToasts.ts
@@ -1,0 +1,54 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
+import { useCallback, useState } from 'react';
+import { IToastContext } from '../contexts/ToastContext';
+
+export function useGlobalToasts(): IToastContext {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const [toastLifeTimeMs, setToastLifeTimeMs] = useState<number>(5000);
+
+  const dismissToast = useCallback(
+    (toast: Toast) => {
+      setToasts(toasts => toasts.filter(t => t !== toast));
+    },
+    [setToasts]
+  );
+
+  const sendToast = useCallback(
+    (toast: Toast) => {
+      setToasts(toasts => [...toasts, toast]);
+    },
+    [setToasts]
+  );
+
+  return {
+    dismissToast,
+    sendToast,
+    setToastLifeTimeMs,
+    toasts,
+    toastLifeTimeMs,
+  };
+}


### PR DESCRIPTION
## Summary

Resolves #194.

## Implementation details

When we save a file, now there will be a toast.

This PR adds a new context and hook associated with initializing the state used by the context. There's also a usage of the context in the `SaveCodeButton` component, so we can notify the user that their file was saved properly.

![20220421135031](https://user-images.githubusercontent.com/18429259/164520659-030e1c3d-f877-46f6-9f1e-44b198811eae.gif)

## How to validate this change

1. Record a journey
1. Use export flyout to expose the save button
1. Click the save button
1. The confirmation toast should appear
1. Make sure you can dismiss the toast, and that it goes away on its own