### PR TITLE
feat: Hide duration element for skipped step

### DIFF
--- a/src/components/TestResult/ResultFlyoutItem.tsx
+++ b/src/components/TestResult/ResultFlyoutItem.tsx
@@ -40,11 +40,13 @@ interface IResultFlyoutItem {
 export function ResultFlyoutItem({ code, step, stepIndex }: IResultFlyoutItem) {
   const { actionTitles, status, error, duration } = step;
 
-  const durationElement = <EuiText size="s">{Math.round(duration / 1000)}s</EuiText>;
-
   return (
     <ResultTitle
-      durationElement={durationElement}
+      durationElement={
+        status !== 'skipped' ? (
+          <EuiText size="s">{Math.round(duration / 1000)}s</EuiText>
+        ) : undefined
+      }
       maxTitleLength={MAX_RESULT_TITLE_LENGTH}
       titleText={step.name}
       stepIndex={stepIndex}


### PR DESCRIPTION
## Summary

Resolves #173.

Hides duration info for steps that never ran.

## Implementation details

### Before

<img width="804" alt="image" src="https://user-images.githubusercontent.com/18429259/164524494-9958d8cb-beda-4e1a-93cb-ee260f146e47.png">


### After

<img width="794" alt="image" src="https://user-images.githubusercontent.com/18429259/164524386-2feb1939-5990-4d1f-ae4a-5ace9f59a870.png">


## How to validate this change

1. Record a journey with multiple steps
2. For any step except the last one, add an assertion you know will fail
3. Run a test
4. Observe that all skipped steps have no duration element displayed