### PR TITLE
feat: Add info icon and tooltip to export as script checkbox

### DIFF
--- a/src/components/ExportScriptFlyout/Body.tsx
+++ b/src/components/ExportScriptFlyout/Body.tsx
@@ -22,7 +22,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { EuiCheckbox, EuiCodeBlock, EuiFlyoutBody, EuiSpacer } from '@elastic/eui';
+import {
+  EuiCheckbox,
+  EuiCodeBlock,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyoutBody,
+  EuiIcon,
+  EuiSpacer,
+  EuiToolTip,
+} from '@elastic/eui';
 import React from 'react';
 import type { Setter } from '../../common/types';
 
@@ -35,12 +44,21 @@ interface Props {
 export function Body({ code, exportAsSuite, setExportAsSuite }: Props) {
   return (
     <EuiFlyoutBody>
-      <EuiCheckbox
-        id="export-as-suite-checkbox"
-        label="Export as suite"
-        checked={exportAsSuite}
-        onChange={() => setExportAsSuite(!exportAsSuite)}
-      />
+      <EuiFlexGroup alignItems="center" gutterSize="s">
+        <EuiFlexItem grow={false}>
+          <EuiCheckbox
+            id="export-as-suite-checkbox"
+            label="Export as suite"
+            checked={exportAsSuite}
+            onChange={() => setExportAsSuite(!exportAsSuite)}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiToolTip content="Export your script as a full suite or an inline journey.">
+            <EuiIcon type="iInCircle" />
+          </EuiToolTip>
+        </EuiFlexItem>
+      </EuiFlexGroup>
       <EuiSpacer />
       <EuiCodeBlock
         id="export-code-block"


### PR DESCRIPTION
## Summary

Resolves #166.

## Implementation details

<img width="316" alt="image" src="https://user-images.githubusercontent.com/18429259/164539032-36fabcd2-5c80-45cd-8465-ba60067427ed.png">


Adds an info icon with a tooltip to add additional context to the `export as script` checkbox.

## How to validate this change

Record a journey, click the export button, and hover over the `iInCircle` icon.