### PR TITLE
feat: Update start over warning modal copy

### DIFF
--- a/src/components/StartOverWarningModal.tsx
+++ b/src/components/StartOverWarningModal.tsx
@@ -68,7 +68,7 @@ export function StartOverWarningModal({ setVisibility, startOver, stepCount }: P
             setVisibility(false);
           }}
         >
-          Delete and start over
+          Start over
         </EuiButton>
       </EuiModalFooter>
     </EuiModal>

--- a/src/components/StartOverWarningModal.tsx
+++ b/src/components/StartOverWarningModal.tsx
@@ -54,7 +54,10 @@ export function StartOverWarningModal({ setVisibility, startOver, stepCount }: P
           <h3>{headerCopy(stepCount)}</h3>
         </EuiModalHeaderTitle>
       </EuiModalHeader>
-      <EuiModalBody>This action cannot be undone.</EuiModalBody>
+      <EuiModalBody>
+        By starting over, the script and all related steps will be permanently deleted. Are you sure
+        you wish to proceed?
+      </EuiModalBody>
       <EuiModalFooter>
         <EuiButtonEmpty onClick={close}>Cancel</EuiButtonEmpty>
         <EuiButton


### PR DESCRIPTION
## Summary

Resolves #164.

## Implementation details

Simply updates the copy in the "Start Over" warning modal.

<img width="850" alt="image" src="https://user-images.githubusercontent.com/18429259/164538551-33fbbd60-f698-44b2-a137-919e46e0e987.png">


## How to validate this change

Record a journey, then click "Start Over" and see the updated copy in the modal.