### PR TITLE
fix: Disable record journey button when URL input is empty

### DIFF
--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -87,7 +87,7 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
         <ControlButton
           aria-label={getPlayControlCopy(recordingStatus, steps.length)}
           color="primary"
-          isDisabled={isTestInProgress}
+          isDisabled={isTestInProgress || !url}
           iconType={recordingStatus === RecordingStatus.Recording ? 'pause' : 'play'}
           fill
           onClick={recordingStatus === RecordingStatus.NotRecording ? toggleRecording : togglePause}


### PR DESCRIPTION
## Summary

Resolves #126.

## Implementation details

Disables the start recording button if the URL field is empty.

<img width="693" alt="image" src="https://user-images.githubusercontent.com/18429259/164543369-727541e3-f579-474f-bd8e-9174e1dd0d03.png">

## How to validate this change

1. Launch the recorder and try to start a journey without a URL.
1. Enter a URL and start recording a journey to ensure the original functionality remains intact.