### PR TITLE
chore: Upgrade React and RTL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3333,9 +3333,9 @@
       }
     },
     "@testing-library/dom": {
-      "version": "8.11.4",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.4.tgz",
-      "integrity": "sha512-7vZ6ZoBEbr6bfEM89W1nzl0vHbuI0g0kRrI0hwSXH3epnuqGO3KulFLQCKfmmW+60t7e4sevAkJPASSMmnNCRw==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.13.0.tgz",
+      "integrity": "sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -3357,26 +3357,23 @@
       }
     },
     "@testing-library/react": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.4.tgz",
-      "integrity": "sha512-jiPKOm7vyUw311Hn/HlNQ9P8/lHNtArAx0PisXyFixDDvfl8DbD6EUdbshK5eqauvBSvzZd19itqQ9j3nferJA==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.1.1.tgz",
+      "integrity": "sha512-8mirlAa0OKaUvnqnZF6MdAh2tReYA2KtWVw1PKvaF5EcCZqgK5pl8iF+3uW90JdG5Ua2c2c2E2wtLdaug3dsVg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.0.0",
-        "@types/react-dom": "*"
+        "@testing-library/dom": "^8.5.0",
+        "@types/react-dom": "^18.0.0"
       }
     },
     "@testing-library/react-hooks": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz",
-      "integrity": "sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.0.tgz",
+      "integrity": "sha512-uZqcgtcUUtw7Z9N32W13qQhVAD+Xki2hxbTR461MKax8T6Jr8nsUvZB+vcBTkzY2nFvsUet434CsgF0ncW2yFw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@types/react": ">=16.9.0",
-        "@types/react-dom": ">=16.9.0",
-        "@types/react-test-renderer": ">=16.9.0",
         "react-error-boundary": "^3.1.0"
       }
     },
@@ -3795,9 +3792,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.14",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.14.tgz",
-      "integrity": "sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.0.tgz",
+      "integrity": "sha512-49897Y0UiCGmxZqpC8Blrf6meL8QUla6eb+BBhn69dTXlmuOlzkfr7HHY/O8J25e1lTUMs+YYxSlVDAaGHCOLg==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -3820,15 +3817,6 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
-      }
-    },
-    "@types/react-test-renderer": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
-      "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*"
       }
     },
     "@types/react-virtualized-auto-sizer": {
@@ -7203,9 +7191,9 @@
       }
     },
     "dom-accessibility-api": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.13.tgz",
-      "integrity": "sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==",
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
+      "integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
       "dev": true
     },
     "dom-converter": {
@@ -15861,12 +15849,11 @@
       }
     },
     "react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.0.0.tgz",
+      "integrity": "sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-app-polyfill": {
@@ -15998,13 +15985,22 @@
       }
     },
     "react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.0.0.tgz",
+      "integrity": "sha512-XqX7uzmFo0pUceWFCt7Gff6IyIMzFUn7QMZrbrQfGxtaxXZIcGQzoNpRLE3fQLnS4XzLLPMZX2T9TRcSrasicw==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.21.0"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.21.0",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+          "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+          "requires": {
+            "loose-envify": "^1.1.0"
+          }
+        }
       }
     },
     "react-dropzone": {
@@ -17521,9 +17517,9 @@
       },
       "dependencies": {
         "trim": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-          "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.3.tgz",
+          "integrity": "sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg=="
         }
       }
     },
@@ -18062,6 +18058,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
     ]
   },
   "devDependencies": {
-    "@testing-library/react": "^12.1.4",
-    "@testing-library/react-hooks": "^7.0.2",
+    "@testing-library/react": "^13.1.1",
+    "@testing-library/react-hooks": "^8.0.0",
     "@types/jest": "^27.4.1",
-    "@types/react-dom": "^17.0.14",
+    "@types/react-dom": "^18.0.0",
     "@types/styled-components": "^5.1.24",
     "ajv": "^8.11.0",
     "concurrently": "^7.0.0",
@@ -88,8 +88,8 @@
     "electron-unhandled": "^3.0.2",
     "moment": "^2.29.1",
     "playwright": "git+https://github.com/elastic/playwright.git#separate-recorder",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "styled-components": "^5.3.5"
   },
   "resolutions": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,12 +23,17 @@ THE SOFTWARE.
 */
 
 import React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOMClient from 'react-dom/client';
 import App from './App';
 
-ReactDOM.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-  document.getElementById('root')
-);
+const element = document.getElementById('root');
+
+if (element) {
+  const root = ReactDOMClient.createRoot(element);
+
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+}


### PR DESCRIPTION
## Summary

Bumps to React 18.

Not ready to merge yet, RTL's `renderHook` does not support React 18 yet, and the hook helpers are being moved over to the main `@testing-library/react` package.

## Implementation details

Will require updates to our hook unit tests.

## How to validate this change

Tests should continue functioning, linting should pass. There shouldn't be material user-facing changes.