### PR TITLE
feat: Add status indicator to assertion elements

### DIFF
--- a/src/components/ActionElement/ActionElement.tsx
+++ b/src/components/ActionElement/ActionElement.tsx
@@ -122,7 +122,7 @@ function ActionComponent({
         />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        {!isAssertion && <ActionStatusIndicator showRect={isLast} status={testStatus} />}
+        <ActionStatusIndicator showRect={isLast} status={testStatus} />
       </EuiFlexItem>
       <Behavior isAssert={isAssertion} omitBorder={isLast}>
         <ActionAccordion

--- a/src/components/ActionElement/Behavior.tsx
+++ b/src/components/ActionElement/Behavior.tsx
@@ -28,7 +28,6 @@ import styled from 'styled-components';
 const AssertItem = styled(EuiFlexItem)`
   border-left: ${props => props.theme.border.thick};
   padding-left: 20px;
-  margin-left: 50px;
 `;
 
 const ActionItem = styled(EuiFlexItem)`


### PR DESCRIPTION
## Summary

Resolves #222.

Adds a status indicator to assertion elements as well as action elements.

## Implementation details

### Before

<img width="467" alt="image" src="https://user-images.githubusercontent.com/18429259/165389191-00dc9247-d925-4166-bbd5-36e401ac56fd.png">


### After

<img width="429" alt="image" src="https://user-images.githubusercontent.com/18429259/165389143-2570f709-d15e-4e37-aa8a-8daff9afd369.png">


## How to validate this change

1. Create an assertion.
1. See the status indicator.

### Other things to check

Ensure the status color changes after a test run