### PR TITLE
fix: Error not showing in failed test result flyout

### DIFF
--- a/electron/execution.ts
+++ b/electron/execution.ts
@@ -206,6 +206,7 @@ async function onTest(data: RunJourneyOptions, browserWindow: BrowserWindow) {
           name: parsed.step.name,
           status: parsed.step.status,
           duration: Math.ceil(parsed.step.duration.us / 1000),
+          error: parsed.error,
         },
       };
     }


### PR DESCRIPTION
## Summary

Fixes a defect we introduced recently as part of the backend transition from pure JS to TypeScript. I'm going to add tests for this function so we don't fail to notice things like this in the future.

### Before

<img width="826" alt="image" src="https://user-images.githubusercontent.com/18429259/165829345-f806f73e-b2f9-4e4a-9b22-0723e9a4aee1.png">

### After

<img width="1078" alt="image" src="https://user-images.githubusercontent.com/18429259/165829217-2fa7dbb4-8140-441d-b5c2-43f04b37e88a.png">


## Implementation details

We simply forgot to include an optional field in the response from the test procedure.

## How to validate this change

Run a journey that you expect to fail, and observe the code/data info in the test result flyout.