### PR TITLE
fix: Refresh action title on update

### DIFF
--- a/src/common/shared.ts
+++ b/src/common/shared.ts
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import type { Step, Steps } from '@elastic/synthetics';
+import type { Action, Step, Steps } from '@elastic/synthetics';
 import { RendererProcessIpc } from 'electron-better-ipc';
 import React from 'react';
 import type { Journey, JourneyType } from '../../common/types';
@@ -136,4 +136,36 @@ export async function getCodeForFailedResult(
   if (!failedStep) return '';
 
   return getCodeFromActions(ipc, [failedStep], journey.type);
+}
+
+export function actionTitle(action: Action) {
+  switch (action.name) {
+    case 'openPage':
+      return `Open new page`;
+    case 'closePage':
+      return `Close page`;
+    case 'check':
+      return `Check ${action.selector}`;
+    case 'uncheck':
+      return `Uncheck ${action.selector}`;
+    case 'click': {
+      if (action.clickCount === 1) return `Click ${action.selector}`;
+      if (action.clickCount === 2) return `Double click ${action.selector}`;
+      if (action.clickCount === 3) return `Triple click ${action.selector}`;
+      return `${action.clickCount}× click`;
+    }
+    case 'fill':
+      return `Fill ${action.selector}`;
+    case 'setInputFiles':
+      if (action.files?.length === 0) return `Clear selected files`;
+      else return `Upload ${action.files?.join(', ')}`;
+    case 'navigate':
+      return `Go to ${action.url}`;
+    case 'press':
+      return `Press ${action.key}` + (action.modifiers ? ' with modifiers' : '');
+    case 'select':
+      return `Select ${action.options?.join(', ')}`;
+    case 'assert':
+      return `Assert`;
+  }
 }

--- a/src/components/ActionDetail/ActionDetail.tsx
+++ b/src/components/ActionDetail/ActionDetail.tsx
@@ -35,13 +35,17 @@ import {
 import { StepsContext } from '../../contexts/StepsContext';
 import { FormControl } from './FormControl';
 import { ActionContext } from '../../common/types';
+import { actionTitle } from '../../common/shared';
 
 function createUpdatedAction(field: string, value: string, context: ActionContext) {
-  return {
+  const actionContext = {
     ...context,
     action: { ...context.action, [field]: value },
     modified: true,
+    isOpen: false,
   };
+  const title = actionTitle(actionContext.action);
+  return title ? { ...actionContext, title } : actionContext;
 }
 
 interface IActionDetail {
@@ -52,18 +56,7 @@ interface IActionDetail {
 }
 
 export function ActionDetail({ actionContext, actionIndex, close, stepIndex }: IActionDetail) {
-  const { steps, onStepDetailChange } = useContext(StepsContext);
-  const onActionContextChange = (updatedAction: ActionContext, updatedActionIndex: number) => {
-    onStepDetailChange(
-      {
-        actions: steps[stepIndex].actions.map((actionToUpdate, index) =>
-          index === updatedActionIndex ? { ...updatedAction, isOpen: false } : actionToUpdate
-        ),
-        name: steps[stepIndex].name,
-      },
-      stepIndex
-    );
-  };
+  const { onUpdateAction } = useContext(StepsContext);
   const { action } = actionContext;
   const [selector, setSelector] = useState(action.selector || '');
   const [text, setText] = useState(action.text || '');
@@ -72,17 +65,17 @@ export function ActionDetail({ actionContext, actionIndex, close, stepIndex }: I
   const onSelectorChange = (value: string) => {
     if (!value) return;
     setSelector(value);
-    onActionContextChange(createUpdatedAction('selector', value, actionContext), actionIndex);
+    onUpdateAction(createUpdatedAction('selector', value, actionContext), stepIndex, actionIndex);
   };
   const onTextChange = (value: string) => {
     if (!value) return;
     setText(value);
-    onActionContextChange(createUpdatedAction('text', value, actionContext), actionIndex);
+    onUpdateAction(createUpdatedAction('text', value, actionContext), stepIndex, actionIndex);
   };
   const onURLChange = (value: string) => {
     if (!value) return;
     setUrl(value);
-    onActionContextChange(createUpdatedAction('url', value, actionContext), actionIndex);
+    onUpdateAction(createUpdatedAction('url', value, actionContext), stepIndex, actionIndex);
   };
 
   if (action.text !== text && typeof action.text !== 'undefined') {

--- a/src/components/Assertion/Assertion.tsx
+++ b/src/components/Assertion/Assertion.tsx
@@ -35,6 +35,7 @@ import {
 import { AssertionSelect } from './Select';
 import { AssertionInfo } from './AssertionInfo';
 import { ActionContext } from '../../common/types';
+import { actionTitle } from '../../common/shared';
 
 interface IAssertion {
   actionContext: ActionContext;
@@ -52,10 +53,12 @@ function updateAction(
   value?: string
 ): ActionContext {
   const { action } = oldAction;
+  const title = actionTitle(action);
   return {
     ...oldAction,
     action: { ...action, command, selector, value },
     isOpen: false,
+    title: title ? title : oldAction?.title,
   };
 }
 

--- a/src/helpers/generator.ts
+++ b/src/helpers/generator.ts
@@ -22,7 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import type { Action, Step, Steps } from '@elastic/synthetics';
+import type { Step, Steps } from '@elastic/synthetics';
+import { actionTitle } from '../common/shared';
 import { ActionContext } from '../common/types';
 
 /**
@@ -47,38 +48,6 @@ export function generateIR(steps: Steps): Steps {
   }
 
   return result;
-}
-
-function actionTitle(action: Action) {
-  switch (action.name) {
-    case 'openPage':
-      return `Open new page`;
-    case 'closePage':
-      return `Close page`;
-    case 'check':
-      return `Check ${action.selector}`;
-    case 'uncheck':
-      return `Uncheck ${action.selector}`;
-    case 'click': {
-      if (action.clickCount === 1) return `Click ${action.selector}`;
-      if (action.clickCount === 2) return `Double click ${action.selector}`;
-      if (action.clickCount === 3) return `Triple click ${action.selector}`;
-      return `${action.clickCount}× click`;
-    }
-    case 'fill':
-      return `Fill ${action.selector}`;
-    case 'setInputFiles':
-      if (action.files?.length === 0) return `Clear selected files`;
-      else return `Upload ${action.files?.join(', ')}`;
-    case 'navigate':
-      return `Go to ${action.url}`;
-    case 'press':
-      return `Press ${action.key}` + (action.modifiers ? ' with modifiers' : '');
-    case 'select':
-      return `Select ${action.options?.join(', ')}`;
-    case 'assert':
-      return `Assert`;
-  }
 }
 
 const getActionCount = (prev: number, cur: Step) => prev + cur.actions.length;


### PR DESCRIPTION
## Summary

Resolves #234.

When running a test, the title shown is not reflective of the other data associated with the action if the user has updated it.

### Before

![20220429160053](https://user-images.githubusercontent.com/18429259/166061406-be5edbe6-6cd4-40e7-8df4-778369706e78.gif)


### After

![20220429160247](https://user-images.githubusercontent.com/18429259/166061645-84087307-4103-4df4-888d-7b054bd55f67.gif)

## Implementation details

I have modified the update logic to call the same `actionTitle()` function that we call when we initially create the action, so the same logic should apply to created and edited actions now.

## How to validate this change

1. Record a journey
1. Modify an action's data so as to update the title (e.g. create a new URL for a `navigate` action
1. Run the journey
1. In the test result flyout, observe that the title of your action reflects the updated value