### PR TITLE
fix: do not generate code when flyout is hidden

### DIFF
--- a/src/components/TestResult/TestResult.tsx
+++ b/src/components/TestResult/TestResult.tsx
@@ -47,12 +47,14 @@ export function TestResult() {
    */
   useEffect(() => {
     async function fetchCodeForFailure(r: Result) {
-      const failedCode = await getCodeFromActions(
-        ipc,
-        // index of failed step will equal number of successful items
-        [steps[r.succeeded]],
-        'inline'
-      );
+      // index of failed step will equal number of successful items
+      const failedStep = steps[r.succeeded];
+      if (failedStep == null) {
+        setStepCodeToDisplay('');
+        return;
+      }
+
+      const failedCode = await getCodeFromActions(ipc, [failedStep], 'inline');
       setStepCodeToDisplay(failedCode);
     }
 
@@ -60,7 +62,7 @@ export function TestResult() {
     if (isResultFlyoutVisible && steps.length && result?.failed) {
       fetchCodeForFailure(result);
     }
-  }, [ipc, result, setResult, steps]);
+  }, [ipc, result, setResult]);
 
   const maxLineLength = useMemo(
     () => stepCodeToDisplay.split('\n').reduce((prev, cur) => Math.max(prev, cur.length), 0),

--- a/src/components/TestResult/TestResult.tsx
+++ b/src/components/TestResult/TestResult.tsx
@@ -57,7 +57,7 @@ export function TestResult() {
     }
 
     // skip procedure when there are no failed steps
-    if (steps.length && result?.failed) {
+    if (isResultFlyoutVisible && steps.length && result?.failed) {
       fetchCodeForFailure(result);
     }
   }, [ipc, result, setResult, steps]);


### PR DESCRIPTION
<!-- Thanks for your pull request. Please fill all of the mandatory fields in this template. That will help us get back to you sooner. -->
fixes #236 
<!-- If it's your first time contributing to an Elastic repo, don't forget to sign our CLA at https://www.elastic.co/contributor-agreement -->

## Summary
When deleting a Step divider after running a test and the result contains failed step, I could observe the uncaught error with the message: 

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'actions')
    at SyntheticsGenerator.findVarsToHoist 
```
I've traced the function that generated the above error and it was the `getCodeFromActions` function called from `TestResult.tsx`. When calling the function, the `actions` parameter was undefined because the function was kept referencing the index 2 from the changed steps which now only have 2 items in the array. Also, the effect hook kept being called with newly rearranged steps even though the test result flyout wasn't visible and it is unncessary.

## Implementation details
1. Do not watch on steps change in effect hook
2. If the failed step doesn't exist due to a changed steps state, do not call `getCodeFromActions` function
3. Run getCodeFromActions code only when `isResultFlyoutVisible` is true

## How to validate this change
1. Record a script that would fail at the last step. 
2. Run the test and confirm that the last step has failed
5. Delete the last step divider
6. No error such as below is printed in the DevTool:
<img width="617" alt="image" src="https://user-images.githubusercontent.com/16660866/166478016-604812bf-19eb-47d3-b1fb-f11c812ebf47.png">

