### PR TITLE
feat: Add a controller class for browser process requests

### DIFF
--- a/common/types.d.ts
+++ b/common/types.d.ts
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
+
 import type { ActionInContext, Steps } from '@elastic/synthetics';
 
 export type ActionContext = ActionInContext & { isOpen?: boolean };
@@ -84,3 +85,15 @@ export type GenerateCodeOptions = {
   actions: Steps;
   isSuite: boolean;
 };
+
+export interface RecordJourneyRequest {
+  data: {
+    url: string;
+  };
+}
+
+export interface TestJourneyRequest {
+  data: RunJourneyOptions;
+}
+
+export type ClientBrowserRequest = RecordJourneyRequest | TestJourneyRequest;

--- a/electron/BrowserRequestController.test.ts
+++ b/electron/BrowserRequestController.test.ts
@@ -1,0 +1,210 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import { BrowserWindow } from 'electron';
+import { RecordJourneyRequest } from '../common/types';
+import { BrowserRequestController } from './BrowserRequestController';
+
+import { error, warn } from 'electron-log';
+import { ipcMain } from 'electron-better-ipc';
+
+jest.mock('electron-log', () => ({
+  error: jest.fn(),
+  warn: jest.fn(),
+}));
+jest.mock('electron-better-ipc', () => ({
+  ipcMain: {
+    callRenderer: jest.fn(),
+  },
+}));
+
+/**
+ * Test class with easily managable state for testing
+ * async nature of `BrowserRequestController`.
+ */
+class TestHandler {
+  private shouldTerminate: boolean;
+  constructor() {
+    this.shouldTerminate = false;
+  }
+  public terminate() {
+    this.shouldTerminate = true;
+  }
+  public isTerminated() {
+    return this.shouldTerminate;
+  }
+}
+
+/**
+ * Helper function to hook up a promise that waits on the test class defined above.
+ *
+ * We can resolve the promise with a call to `testHandler.terminate()`, which will simulate
+ * a browser-dependent process resolving.
+ */
+function createTestPromise(): [TestHandler, Promise<void>] {
+  const testHandler = new TestHandler();
+  const executionPromise = new Promise<void>(async resolve => {
+    while (!testHandler.isTerminated()) {
+      await new Promise(r => setTimeout(r, 10));
+    }
+    resolve();
+  });
+  return [testHandler, executionPromise];
+}
+
+describe('BrowserRequestController', () => {
+  let journeyRequest: RecordJourneyRequest;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    journeyRequest = {
+      data: {
+        url: 'https://www.elastic.co/',
+      },
+    };
+  });
+
+  it('sets the buffer when a new request is issued', async () => {
+    const controller = new BrowserRequestController();
+
+    const [testHandler, executionPromise] = createTestPromise();
+
+    const controllerExecution = controller.executeRequest(
+      journeyRequest,
+      jest.fn() as unknown as BrowserWindow,
+      async (_, __) => await executionPromise
+    );
+
+    expect(controller.getBuffer()).not.toBeNull();
+
+    testHandler.terminate();
+
+    await controllerExecution;
+
+    expect(controller.getBuffer()).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('sends warning for record journey request when process already running', async () => {
+    const controller = new BrowserRequestController();
+
+    const [testHandler, executionPromise] = createTestPromise();
+
+    const controllerExecution = controller.executeRequest(
+      journeyRequest,
+      jest.fn() as unknown as BrowserWindow,
+      async (_, __) => await executionPromise
+    );
+
+    expect(controller.getBuffer()).not.toBeNull();
+
+    // define objects and make a second request before the first is resolved
+    const secondRequest = { data: { url: 'anotherurl' } };
+    const secondBrowserWindow = jest.fn() as unknown as BrowserWindow;
+    controller.executeRequest(secondRequest, secondBrowserWindow, async (_, __) => {
+      return;
+    });
+
+    // resolve the original request
+    testHandler.terminate();
+
+    await controllerExecution;
+
+    expect(controller.getBuffer()).toBeNull();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      'Cannot start recording a journey, a browser operation is already in progress.'
+    );
+    expect(ipcMain.callRenderer).toHaveBeenCalledTimes(1);
+    expect(ipcMain.callRenderer).toHaveBeenCalledWith(
+      secondBrowserWindow,
+      'browser-request-failure',
+      secondRequest
+    );
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('sends warning for test journey request when process already running', async () => {
+    const controller = new BrowserRequestController();
+
+    const [testHandler, executionPromise] = createTestPromise();
+
+    const controllerExecution = controller.executeRequest(
+      journeyRequest,
+      jest.fn() as unknown as BrowserWindow,
+      async (_, __) => await executionPromise
+    );
+
+    expect(controller.getBuffer()).not.toBeNull();
+
+    // define objects and make a second request before the first is resolved
+    const secondRequest = { data: { steps: [], code: '', isSuite: true } };
+    const secondBrowserWindow = jest.fn() as unknown as BrowserWindow;
+    controller.executeRequest(secondRequest, secondBrowserWindow, async (_, __) => {
+      return;
+    });
+
+    // resolve the original request
+    testHandler.terminate();
+    await controllerExecution;
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      'Cannot start testing a journey, a browser operation is already in progress.'
+    );
+    expect(ipcMain.callRenderer).toHaveBeenCalledTimes(1);
+    expect(ipcMain.callRenderer).toHaveBeenCalledWith(
+      secondBrowserWindow,
+      'browser-request-failure',
+      secondRequest
+    );
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('logs error and clears the buffer', async () => {
+    const controller = new BrowserRequestController();
+
+    const [testHandler, executionPromise] = createTestPromise();
+
+    const controllerExecution = controller.executeRequest(
+      journeyRequest,
+      jest.fn() as unknown as BrowserWindow,
+      async (_, __) => {
+        await executionPromise;
+        // throw an error before resolving the promise to trigger internal error handling
+        throw new Error('test error');
+      }
+    );
+    expect(controller.getBuffer()).not.toBeNull();
+
+    testHandler.terminate();
+    await controllerExecution;
+
+    expect(controller.getBuffer()).toBeNull();
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(error).toHaveBeenCalledWith(new Error('test error'));
+  });
+});

--- a/electron/BrowserRequestController.ts
+++ b/electron/BrowserRequestController.ts
@@ -1,0 +1,81 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import { BrowserWindow } from 'electron';
+import { ipcMain as ipc } from 'electron-better-ipc';
+import logger from 'electron-log';
+import type { ClientBrowserRequest, RecordJourneyRequest } from '../common/types';
+import { isTestJourneyRequest } from '../src/common/shared';
+
+const isRecordJourneyRequest = (req: any): req is RecordJourneyRequest => !!req?.data?.url;
+
+export class BrowserRequestController {
+  private buffer: ClientBrowserRequest | null;
+
+  constructor() {
+    this.buffer = null;
+  }
+
+  public async executeRequest<T>(
+    req: ClientBrowserRequest,
+    browserWindow: BrowserWindow,
+    execution: (req: ClientBrowserRequest, browserWindow: BrowserWindow) => Promise<T>
+  ): Promise<T | undefined> {
+    const isRecordingRequest = isRecordJourneyRequest(req);
+    const isTestRequest = isTestJourneyRequest(req);
+    if (!this.canRunRequest()) {
+      if (isRecordingRequest) {
+        logger.warn(
+          'Cannot start recording a journey, a browser operation is already in progress.'
+        );
+      } else if (isTestRequest) {
+        logger.warn('Cannot start testing a journey, a browser operation is already in progress.');
+      }
+      // drop any requests we receive while a browser is running
+      return ipc.callRenderer(browserWindow, 'browser-request-failure', req);
+    }
+
+    this.buffer = req;
+
+    try {
+      return await execution(req, browserWindow);
+    } catch (e) {
+      logger.error(e);
+    } finally {
+      this.clearBuffer();
+    }
+  }
+
+  private canRunRequest() {
+    return this.buffer === null;
+  }
+
+  private clearBuffer() {
+    this.buffer = null;
+  }
+
+  public getBuffer() {
+    return this.buffer;
+  }
+}

--- a/src/common/shared.ts
+++ b/src/common/shared.ts
@@ -143,8 +143,6 @@ export async function getCodeForFailedResult(
   return getCodeFromActions(ipc, [failedStep], journey.type);
 }
 
-export const isRecordJourneyRequest = (req: any): req is RecordJourneyRequest => !!req?.data?.url;
-
 export const isTestJourneyRequest = (req: any): req is TestJourneyRequest =>
   Array.isArray(req?.data?.steps) &&
   typeof req?.data?.code === 'string' &&

--- a/src/common/shared.ts
+++ b/src/common/shared.ts
@@ -25,7 +25,12 @@ THE SOFTWARE.
 import type { Step, Steps } from '@elastic/synthetics';
 import { RendererProcessIpc } from 'electron-better-ipc';
 import React from 'react';
-import type { Journey, JourneyType } from '../../common/types';
+import type {
+  Journey,
+  JourneyType,
+  RecordJourneyRequest,
+  TestJourneyRequest,
+} from '../../common/types';
 
 export const COMMAND_SELECTOR_OPTIONS = [
   {
@@ -137,3 +142,10 @@ export async function getCodeForFailedResult(
 
   return getCodeFromActions(ipc, [failedStep], journey.type);
 }
+
+export const isRecordJourneyRequest = (req: any): req is RecordJourneyRequest => !!req?.data?.url;
+
+export const isTestJourneyRequest = (req: any): req is TestJourneyRequest =>
+  Array.isArray(req?.data?.steps) &&
+  typeof req?.data?.code === 'string' &&
+  typeof req?.data?.isSuite === 'boolean';

--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -72,7 +72,6 @@ export function HeaderControls({ setIsCodeFlyoutVisible }: IHeaderControls) {
 
   useEffect(() => {
     const listener = (request: ClientBrowserRequest) => {
-      console.log('hi from listener!', request);
       if (isTestInProgress && isTestJourneyRequest(request)) {
         setIsTestInProgress(false);
         setResult(undefined);

--- a/src/contexts/CommunicationContext.ts
+++ b/src/contexts/CommunicationContext.ts
@@ -27,7 +27,7 @@ import { createContext } from 'react';
 
 const { ipcRenderer } = window.require('electron-better-ipc');
 
-interface ICommunicationContext {
+export interface ICommunicationContext {
   ipc: RendererProcessIpc;
 }
 

--- a/src/helpers/test/defaults.ts
+++ b/src/helpers/test/defaults.ts
@@ -23,6 +23,7 @@ THE SOFTWARE.
 */
 
 import { RecordingStatus } from '../../common/types';
+import { ICommunicationContext } from '../../contexts/CommunicationContext';
 import { IRecordingContext } from '../../contexts/RecordingContext';
 import { IStepsContext } from '../../contexts/StepsContext';
 import { IUrlContext } from '../../contexts/UrlContext';
@@ -55,4 +56,13 @@ export const getStepsContextDefaults = (): IStepsContext => ({
   onSplitStep: jest.fn(),
   onStepDetailChange: jest.fn(),
   onUpdateAction: jest.fn(),
+});
+
+export const getCommunicationContextDefaults = (): ICommunicationContext => ({
+  // @ts-expect-error partial implementation for testing
+  ipc: {
+    answerMain: jest.fn(),
+    callMain: jest.fn(),
+    removeListener: jest.fn(),
+  },
 });

--- a/src/helpers/test/render.tsx
+++ b/src/helpers/test/render.tsx
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 import { render as rtlRender, RenderResult, RenderOptions } from '@testing-library/react';
 import React from 'react';
+import { CommunicationContext, ICommunicationContext } from '../../contexts/CommunicationContext';
 import { IRecordingContext, RecordingContext } from '../../contexts/RecordingContext';
 import { IStepsContext, StepsContext } from '../../contexts/StepsContext';
 import { StyledComponentsEuiProvider } from '../../contexts/StyledComponentsEuiProvider';
@@ -32,6 +33,7 @@ import {
   getRecordingContextDefaults,
   getUrlContextDefaults,
   getStepsContextDefaults,
+  getCommunicationContextDefaults,
 } from './defaults';
 import { RenderContexts } from './RenderContexts';
 
@@ -40,6 +42,7 @@ export function render<ComponentType>(
   rtlRenderOptions?: Omit<RenderOptions, 'queries'>,
   options?: {
     contextOverrides?: {
+      communication?: Partial<ICommunicationContext>;
       recording?: Partial<IRecordingContext>;
       steps?: Partial<IStepsContext>;
       url?: Partial<IUrlContext>;
@@ -61,6 +64,11 @@ export function render<ComponentType>(
       defaults: getStepsContextDefaults(),
       Context: StepsContext,
       overrides: options?.contextOverrides?.steps,
+    },
+    {
+      defaults: getCommunicationContextDefaults(),
+      Context: CommunicationContext,
+      overrides: options?.contextOverrides?.communication,
     },
   ];
 


### PR DESCRIPTION
## Summary

Resolves #149.

## Implementation details

Adds a class for managing browser process handlers. We have already disallowed the client to send test/record requests while there's already a session in progress. The backend code does not regulate this, however.

This patch adds a new class that will keep a reference to a current request, and clear the request after it resolves. Any subsequent requests will log a warning and call an IPC failure channel. Errors in the process are likewise logged before the process buffer is cleared.

At the moment the class only buffers a single process. It will be easy to extend to holding additional processes in the future if we want to add functionality that requires it.

## How to validate this change

Ensure that you cannot start multiple browser-dependent processes at the same time.

You can remove the check if a test is in progress from the Start Button's [`disabled`](https://github.com/elastic/synthetics-recorder/blob/main/src/components/Header/HeaderControls.tsx#L90) prop.

1. Record a long journey
2. Run a test
3. Attempt to start recording
4. You should be able to see a warning logged that there's already a process running
