### PR TITLE
feat: Add option to build `arm64` binary

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -19,6 +19,9 @@ mac:
   extraResources:
     - from: local-browsers/_releases/mac
       to: local-browsers
+  target:
+    target: default
+    arch: [x64, arm64]
 win:
   target: nsis
   icon: public/elastic.png

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,6 @@
 productName: "Elastic Synthetics Recorder"
 appId: co.elastic.synthetics-recorder
+artifactName: ${productName}-${version}-${os}-${arch}.${ext}
 beforePack: "./scripts/before-pack.js"
 afterPack: "./scripts/after-pack.js"
 files:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -5,6 +5,9 @@ afterPack: "./scripts/after-pack.js"
 files:
   - build/**/*
   - scripts/**/*
+extraResources:
+  - from: local-browsers/_releases/${os}-${arch}
+    to: local-browsers
 publish:
   - provider: github
 extraMetadata:
@@ -16,26 +19,17 @@ protocols:
 mac:
   icon: public/elastic.png
   category: public.app-category.developer-tools
-  extraResources:
-    - from: local-browsers/_releases/mac
-      to: local-browsers
   target:
     target: default
     arch: [x64, arm64]
 win:
   target: nsis
   icon: public/elastic.png
-  extraResources:
-    - from: local-browsers/_releases/win
-      to: local-browsers
 linux:
   target:
     - deb
   icon: public/elastic.png
   category: Utility
-  extraResources:
-    - from: local-browsers/_releases/linux
-      to: local-browsers
   # electron-builder issue:
   # https://github.com/electron-userland/electron-builder/issues/6200#issuecomment-907830847
   asarUnpack:

--- a/scripts/before-pack.js
+++ b/scripts/before-pack.js
@@ -28,10 +28,10 @@ const { downloadForPlatform } = require('./download-chromium');
 exports.default = function beforePack(ctx) {
   const arch = Arch[ctx.arch];
   const platform = ctx.electronPlatformName;
-  return Promise.all([downloadForPlatform(platform), fixSharp(arch, platform)]);
+  return Promise.all([downloadForPlatform(platform, arch), fixSharp(platform, arch)]);
 };
 
-function fixSharp(arch, platform) {
+function fixSharp(platform, arch) {
   return new Promise((resolve, reject) => {
     const npmInstall = spawn('npm', ['run', 'fix-sharp'], {
       stdio: 'inherit',

--- a/scripts/download-chromium.js
+++ b/scripts/download-chromium.js
@@ -39,7 +39,7 @@ const DOWNLOAD_URLS = {
   linux: '%s/builds/chromium/%s/chromium-linux.zip',
   mac: '%s/builds/chromium/%s/chromium-mac.zip',
   win: '%s/builds/chromium/%s/chromium-win64.zip',
-  // 'mac-arm64': '%s/builds/chromium/%s/chromium-mac-arm64.zip',
+  'mac-arm64': '%s/builds/chromium/%s/chromium-mac-arm64.zip',
 };
 
 async function download(platform, revision, directory) {

--- a/scripts/download-chromium.js
+++ b/scripts/download-chromium.js
@@ -42,14 +42,19 @@ const DOWNLOAD_URLS = {
   'mac-arm64': '%s/builds/chromium/%s/chromium-mac-arm64.zip',
 };
 
-async function download(platform, revision, directory) {
+async function download(platform, arch, revision, directory) {
+  const platformAndArch = `${platform}-${arch}`;
   const executablePath = findExecutablePath(directory, platform);
   const downloadHost =
     process.env['PLAYWRIGHT_DOWNLOAD_HOST'] || 'https://playwright.azureedge.net';
-  const downloadURL = util.format(DOWNLOAD_URLS[platform], downloadHost, revision);
-  const title = `chromium v${revision} for ${platform}`;
-  const downloadFileName = `playwright-download-chromium-${platform}-${revision}.zip`;
+  const url = DOWNLOAD_URLS[platformAndArch] ?? DOWNLOAD_URLS[platform];
+  const downloadURL = util.format(url, downloadHost, revision);
+  const title = `chromium v${revision} for ${platformAndArch}`;
+  const downloadFileName = `playwright-download-chromium-${platformAndArch}-${revision}.zip`;
   try {
+    if (executablePath == null) {
+      throw new Error('executablePath not found');
+    }
     // eslint-disable-next-line no-console
     console.info('Downloading browser ', title);
     await downloadBrowserWithProgressBar(
@@ -80,15 +85,15 @@ function translatePlatform(platform) {
   }
 }
 
-exports.downloadForPlatform = async function downloadForPlatform(platform) {
-  platform = translatePlatform(platform);
+exports.downloadForPlatform = async function downloadForPlatform(electron_platform, arch) {
+  const platform = translatePlatform(electron_platform);
   const [, revision] = getChromeVersion().split('-');
   const directory = path.join(
     process.cwd(),
     'local-browsers',
     '_releases',
-    platform,
+    `${platform}-${arch}`,
     getChromeVersion()
   );
-  await download(platform, revision, directory);
+  await download(platform, arch, revision, directory);
 };

--- a/scripts/download-chromium.js
+++ b/scripts/download-chromium.js
@@ -53,7 +53,7 @@ async function download(platform, arch, revision, directory) {
   const downloadFileName = `playwright-download-chromium-${platformAndArch}-${revision}.zip`;
   try {
     if (executablePath == null) {
-      throw new Error('executablePath not found');
+      throw new Error('Executable path for playwright browser not found');
     }
     // eslint-disable-next-line no-console
     console.info('Downloading browser ', title);


### PR DESCRIPTION
## Summary

Resolves #248.

Causes the `build`/`release` scripts to generate an Apple silicon binary in addition to the Intel one.

## Implementation details

Simply updates the build config for the recorder.

## How to validate this change

You can do an `npm run pack` command to build fresh binaries locally. You should be able to run both the `x64` and the `arm64` versions without issues.