### PR TITLE
fix: Browser will not launch after manual termination of test run

### DIFF
--- a/electron/execution.ts
+++ b/electron/execution.ts
@@ -144,8 +144,9 @@ function onRecordJourneys(mainWindowEmitter: EventEmitter) {
       mainWindowEmitter.removeListener(MainWindowEvent.MAIN_CLOSE, handleMainClose);
     } catch (e) {
       logger.error(e);
+    } finally {
+      isBrowserRunning = false;
     }
-    isBrowserRunning = false;
   };
 }
 
@@ -335,8 +336,8 @@ function onTest(mainWindowEmitter: EventEmitter) {
           `Attempted to send SIGTERM to synthetics process, but did not receive exit signal. Process ID is ${synthCliProcess.pid}.`
         );
       }
+      isBrowserRunning = false;
     }
-    isBrowserRunning = false;
   };
 }
 

--- a/electron/execution.ts
+++ b/electron/execution.ts
@@ -101,8 +101,8 @@ function onRecordJourneys(mainWindowEmitter: EventEmitter) {
         'Cannot start recording a journey, a browser operation is already in progress.'
       );
     }
+    isBrowserRunning = true;
     try {
-      isBrowserRunning = true;
       const { browser, context } = await launchContext();
       const closeBrowser = async () => {
         browserContext = null;
@@ -144,9 +144,8 @@ function onRecordJourneys(mainWindowEmitter: EventEmitter) {
       mainWindowEmitter.removeListener(MainWindowEvent.MAIN_CLOSE, handleMainClose);
     } catch (e) {
       logger.error(e);
-    } finally {
-      isBrowserRunning = false;
     }
+    isBrowserRunning = false;
   };
 }
 
@@ -185,6 +184,7 @@ function onTest(mainWindowEmitter: EventEmitter) {
         'Cannot start testing a journey, a browser operation is already in progress.'
       );
     }
+    isBrowserRunning = true;
     const parseOrSkip = (chunk: string): Array<Record<string, any>> => {
       // at times stdout ships multiple steps in one chunk, broken by newline,
       // so here we split on the newline
@@ -282,8 +282,6 @@ function onTest(mainWindowEmitter: EventEmitter) {
         args.unshift(filePath);
       }
 
-      isBrowserRunning = true;
-
       /**
        * Fork the Synthetics CLI with correct browser path and
        * cwd correctly spawns the process
@@ -337,8 +335,8 @@ function onTest(mainWindowEmitter: EventEmitter) {
           `Attempted to send SIGTERM to synthetics process, but did not receive exit signal. Process ID is ${synthCliProcess.pid}.`
         );
       }
-      isBrowserRunning = false;
     }
+    isBrowserRunning = false;
   };
 }
 

--- a/electron/execution.ts
+++ b/electron/execution.ts
@@ -122,10 +122,12 @@ function onRecordJourneys(mainWindowEmitter: EventEmitter) {
       actionListener = new EventEmitter();
       actionListener.on('actions', actionsHandler);
 
-      const handleMainClose = async () => {
+      const handleMainClose = () => {
         actionListener.removeAllListeners();
         ipc.removeListener('stop', closeBrowser);
-        return browser.close();
+        browser.close().catch(() => {
+          isBrowserRunning = false;
+        });
       };
 
       mainWindowEmitter.addListener(MainWindowEvent.MAIN_CLOSE, handleMainClose);


### PR DESCRIPTION
## Summary

Resolves #255.

Check the issue above for detailed repro steps - essentially if the user terminates the PW browser during a test run, the Recorder can't open the browser back up again ever.

## Implementation details

We [recently introduced ](https://github.com/elastic/synthetics-recorder/pull/241/files#diff-33107fe7222398333570c06513ba085b86bd3564c21860f8a70886736dff81e6R91) an `isBrowserRunning` flag to prevent the recorder from launching unbounded browser instances.

Unfortunately, I failed to ensure that the flag would be reset in all cases. This change should correct that. It nests all setting of the `isBrowserRunning` flag inside of the pre-existing `try...catch...finally` blocks that the affected functions contain; whether the browser terminates manually or as planned, these flags should be reset afterwards.

## How to validate this change

Use the repro steps to confirm the problem on `main`, and then checkout and run this branch to observe that this patch resolves the problem.