### PR TITLE
chore: Bump EUI to v58

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1800,9 +1800,9 @@
       }
     },
     "@elastic/eui": {
-      "version": "55.1.3",
-      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-55.1.3.tgz",
-      "integrity": "sha512-Hf6eN9YKOKAQMMS9OV5pHLUkzpKKAxGYNVSfc/KK7hN9BlhlHH4OaZIQP3Psgf5GKoqhZrldT/N65hujk3rlLA==",
+      "version": "58.0.0",
+      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-58.0.0.tgz",
+      "integrity": "sha512-LE6yzfu2PfiPVcgyiTURm1ypYtLiVX8YlAgypqN3f6QB89Q1UBeb2njeqyBubzpzOpC/OU1a98CgWy2YWl+0mg==",
       "requires": {
         "@types/chroma-js": "^2.0.0",
         "@types/lodash": "^4.14.160",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
-    "@elastic/eui": "^55.0.1",
+    "@elastic/eui": "^58.0.0",
     "@elastic/synthetics": "=1.0.0-beta.23",
     "@emotion/cache": "^11.7.1",
     "@emotion/react": "^11.8.2",


### PR DESCRIPTION
## Summary

Bumps EUI to the latest version.

Aside from simply upgrading EUI, this version of the library eliminates some annoying erroneous error logging that has been plaguing the recorder for months.

## Implementation details

Simply updates the EUI dependency, and its associated packages.

## How to validate this change

The only changes would be visual, and they are likely minute changes.