### PR TITLE
ci: upload exe files

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -166,8 +166,8 @@ pipeline {
         RELEASE_URL_MESSAGE = "(<https://github.com/elastic/${env.REPO}/releases/tag/${env.TAG_NAME}|${env.TAG_NAME}>)"
       }
       // There are some environmental issues with some of the CI workers
-      // let's use the one we know it works.      
-      //agent { label 'macos-code-signer' }      
+      // let's use the one we know it works.
+      //agent { label 'macos-code-signer' }
       agent { label 'worker-c07yc0cejyvy' }
       stages {
         stage('Dist') {
@@ -186,12 +186,11 @@ pipeline {
           options { skipDefaultCheckout() }
           steps {
             dir("${BASE_DIR}") {
-              uploadBinariesToBeSigned(['deb', 'dmg', 'zip'])
+              uploadBinariesToBeSigned(['deb', 'dmg', 'zip', 'exe'])
               build(job: 'elastic+unified-release+master+sign-artifacts-with-gpg',
                     parameters: [string(name: 'gcs_input_path', value: "${env.BUCKET_PATH}")],
                     wait: true,
                     propagate: true)
-              uploadBinariesToBeSigned(['exe'])
             }
           }
         }


### PR DESCRIPTION
## Summary

Upload exe files to the google bucket so the release will consume those binaries