### PR TITLE
fix protocol build config

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -14,9 +14,9 @@ publish:
 extraMetadata:
   main: build/electron/electron.js
 protocols:
-  - name: elastic-synthetics-recorder
-    schemes:
-      - elastic-synthetics-recorder
+  name: elastic-synthetics-recorder
+  schemes:
+    - elastic-synthetics-recorder
 mac:
   icon: public/elastic.png
   category: public.app-category.developer-tools


### PR DESCRIPTION
fix protocol build config, protocols key takes an object instead of array 


originally this was defined in package.json as json, but when it got moved to yaml format in this PR https://github.com/elastic/synthetics-recorder/pull/165

protocols got defined as array, which means it stopped working. 
