### PR TITLE
fix: remove dashes in app name

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
-productName: "Elastic-Synthetics-Recorder"
+productName: "Elastic Synthetics Recorder"
 appId: co.elastic.synthetics-recorder
-artifactName: ${productName}-${version}-${os}-${arch}.${ext}
+artifactName: ${name}-${version}-${os}-${arch}.${ext}
 beforePack: "./scripts/before-pack.js"
 afterPack: "./scripts/after-pack.js"
 files:


### PR DESCRIPTION
## Summary
The latest builds have an app name "Elastic-Synthetics-Recorder". Before this, it was "Elastic Synthetics Recorder" (the current build has dashes between the words.)

<!-- What does this change do? Which issue does it solve? -->

<!-- If you have any screenshots or GIFs, here's where you should include them. -->
![image](https://user-images.githubusercontent.com/16660866/171213641-fa3c4000-2132-4521-8b6f-9d80958a6c54.png)

## Implementation details
In `electron-build.yml`, revert the `productName` field to have empty spaces instead of dashes. At the same time, in order to prevent any issue with empty space in artifacts name, we will use the `name` field from `package.json` instead of productName which does not contain empty space at all times. 


I'd love to check with @v1v about the change introduced [here](https://github.com/elastic/synthetics-recorder/pull/238/files#diff-abfd13c4441842dc2fc303311c40908ecd004ecec4c4bb5827c366b454a1f721L1) was due to the empty spaces in the productName having side effect when building artifacts. (If that was the only reason I've configured the electron-builder to use another field that doesn't have any empty space for artifacts name).

## How to validate this change
1. run `npm run pack -- -mwl` locally.
2.Go to `dist` directory and check the unpacked apps do not contain dashes in their name:
<img width="378" alt="image" src="https://user-images.githubusercontent.com/16660866/171213950-eaf358fe-c265-439f-8ef5-2547d4a3a29d.png">
or install the app and confirm:
<img width="187" alt="image" src="https://user-images.githubusercontent.com/16660866/171213853-dcc49086-ecf9-43a4-ab16-389680137900.png">

3. Also check all the builds have the same naming convention.(if artifacts name had an empty space, it would have different format as it was in the previous [releases](https://github.com/elastic/synthetics-recorder/releases/tag/v0.0.1-alpha.3): 
<img width="409" alt="image" src="https://user-images.githubusercontent.com/16660866/171210369-b55a090c-1c24-4a4d-84f7-dd93be182ff7.png">

<!-- How can others validate that what you've done is correct? -->

<!-- Is there any particular subject on which you need more input? -->
