### PR TITLE
chore: rename `suites` to `projects`

### DIFF
--- a/common/types.d.ts
+++ b/common/types.d.ts
@@ -37,7 +37,7 @@ interface RecorderSteps<StepType = RecorderStep> extends Steps {
 }
 
 export type StepStatus = 'succeeded' | 'failed' | 'skipped';
-export type JourneyType = 'suite' | 'inline';
+export type JourneyType = 'project' | 'inline';
 
 export interface JourneyStep {
   duration: number;
@@ -90,9 +90,9 @@ export type RecordJourneyOptions = { url: string };
 export type RunJourneyOptions = {
   steps: Steps;
   code: string;
-  isSuite: boolean;
+  isProject: boolean;
 };
 export type GenerateCodeOptions = {
   actions: Steps;
-  isSuite: boolean;
+  isProject: boolean;
 };

--- a/electron/config.ts
+++ b/electron/config.ts
@@ -35,7 +35,7 @@ const ROOT_DIR = process.cwd();
 
 /**
  * Journey directory is for storing a dummy file to simulate
- * the suite tests
+ * the project tests
  */
 export const JOURNEY_DIR = isDev ? join(ROOT_DIR, 'journeys') : join(RESOURCES_PATH, 'journeys');
 

--- a/electron/execution.ts
+++ b/electron/execution.ts
@@ -275,10 +275,10 @@ function onTest(mainWindowEmitter: EventEmitter) {
     let synthCliProcess: ChildProcess | null = null; // child process, define here to kill when finished
 
     try {
-      const isSuite = data.isSuite;
+      const isProject = data.isProject;
       const args = ['--no-headless', '--reporter=json', '--screenshots=off', '--no-throttling'];
       const filePath = join(JOURNEY_DIR, 'recorded.journey.js');
-      if (!isSuite) {
+      if (!isProject) {
         args.push('--inline');
       } else {
         await mkdir(JOURNEY_DIR, { recursive: true });
@@ -307,7 +307,7 @@ function onTest(mainWindowEmitter: EventEmitter) {
       mainWindowEmitter.addListener(MainWindowEvent.MAIN_CLOSE, handleMainClose);
 
       const { stdout, stdin, stderr } = synthCliProcess as ChildProcess;
-      if (!isSuite) {
+      if (!isProject) {
         stdin?.write(data.code);
         stdin?.end();
       }
@@ -319,7 +319,7 @@ function onTest(mainWindowEmitter: EventEmitter) {
       for await (const chunk of stderr!) {
         logger.error(chunk);
       }
-      if (isSuite) {
+      if (isProject) {
         await rm(filePath, { recursive: true, force: true });
       }
 
@@ -357,8 +357,8 @@ async function onFileSave(code: string) {
   return false;
 }
 
-async function onGenerateCode(data: { isSuite: boolean; actions: RecorderSteps }) {
-  const generator = new SyntheticsGenerator(data.isSuite);
+async function onGenerateCode(data: { isProject: boolean; actions: RecorderSteps }) {
+  const generator = new SyntheticsGenerator(data.isProject);
   return generator.generateFromSteps(data.actions);
 }
 

--- a/electron/syntheticsGenerator.ts
+++ b/electron/syntheticsGenerator.ts
@@ -146,7 +146,7 @@ export class SyntheticsGenerator extends PlaywrightGenerator.JavaScriptLanguageG
   private insideStep: boolean;
   private varsToHoist: string[];
 
-  constructor(private isSuite: boolean) {
+  constructor(private isProject: boolean) {
     super(true);
     this.insideStep = false;
     this.previousContext = undefined;
@@ -170,7 +170,7 @@ export class SyntheticsGenerator extends PlaywrightGenerator.JavaScriptLanguageG
     }
 
     const stepIndent = this.insideStep ? 2 : 0;
-    const offset = this.isSuite ? 2 + stepIndent : 0 + stepIndent;
+    const offset = this.isProject ? 2 + stepIndent : 0 + stepIndent;
     const formatter = new PlaywrightGenerator.JavaScriptFormatter(offset);
 
     const subject = actionInContext.isMainFrame
@@ -296,7 +296,7 @@ export class SyntheticsGenerator extends PlaywrightGenerator.JavaScriptLanguageG
    */
   generateFromSteps(steps: RecorderSteps): string {
     const text = [];
-    if (this.isSuite) {
+    if (this.isProject) {
       text.push(this.generateHeader());
     }
     this.varsToHoist = this.findVarsToHoist(steps);
@@ -313,7 +313,7 @@ export class SyntheticsGenerator extends PlaywrightGenerator.JavaScriptLanguageG
 
       text.push(this.generateStepEnd());
     }
-    if (this.isSuite) {
+    if (this.isProject) {
       text.push(this.generateFooter());
     }
 
@@ -333,7 +333,7 @@ export class SyntheticsGenerator extends PlaywrightGenerator.JavaScriptLanguageG
   }
 
   getDefaultOffset() {
-    return this.isSuite ? 2 : 0;
+    return this.isProject ? 2 : 0;
   }
 
   /**

--- a/src/common/shared.test.ts
+++ b/src/common/shared.test.ts
@@ -105,7 +105,7 @@ describe('shared', () => {
       expect(mockIpc.callMain).toHaveBeenCalledTimes(1);
       expect(mockIpc.callMain).toHaveBeenCalledWith('actions-to-code', {
         actions: [failedStep],
-        isSuite: false,
+        isProject: false,
       });
     });
   });

--- a/src/common/shared.ts
+++ b/src/common/shared.ts
@@ -81,7 +81,7 @@ export async function getCodeFromActions(
       ...rest,
       actions: actions.filter(action => !(action as ActionContext)?.isSoftDeleted),
     })),
-    isSuite: type === 'suite',
+    isProject: type === 'project',
   });
 }
 

--- a/src/components/ExportScriptFlyout/Body.tsx
+++ b/src/components/ExportScriptFlyout/Body.tsx
@@ -28,18 +28,18 @@ import type { Setter } from '../../common/types';
 
 interface Props {
   code: string;
-  exportAsSuite: boolean;
-  setExportAsSuite: Setter<boolean>;
+  exportAsProject: boolean;
+  setExportAsProject: Setter<boolean>;
 }
 
-export function Body({ code, exportAsSuite, setExportAsSuite }: Props) {
+export function Body({ code, exportAsProject, setExportAsProject }: Props) {
   return (
     <EuiFlyoutBody>
       <EuiCheckbox
-        id="export-as-suite-checkbox"
-        label="Export as suite"
-        checked={exportAsSuite}
-        onChange={() => setExportAsSuite(!exportAsSuite)}
+        id="export-as-project-checkbox"
+        label="Export as project"
+        checked={exportAsProject}
+        onChange={() => setExportAsProject(!exportAsProject)}
       />
       <EuiSpacer />
       <EuiCodeBlock

--- a/src/components/ExportScriptFlyout/Flyout.tsx
+++ b/src/components/ExportScriptFlyout/Flyout.tsx
@@ -45,9 +45,9 @@ const LARGE_FLYOUT_SIZE_LINE_LENGTH = 100;
 export function ExportScriptFlyout({ setVisible, steps }: IExportScriptFlyout) {
   const [code, setCode] = useState('');
   const { ipc } = useContext(CommunicationContext);
-  const [exportAsSuite, setExportAsSuite] = useState(false);
+  const [exportAsProject, setExportAsProject] = useState(false);
 
-  const type: JourneyType = exportAsSuite ? 'suite' : 'inline';
+  const type: JourneyType = exportAsProject ? 'project' : 'inline';
 
   const maxLineSize = useMemo(
     // get max line size in code string
@@ -69,7 +69,7 @@ export function ExportScriptFlyout({ setVisible, steps }: IExportScriptFlyout) {
       size={maxLineSize > LARGE_FLYOUT_SIZE_LINE_LENGTH ? 'l' : 'm'}
     >
       <Header headerText="Journey code" id={FLYOUT_ID} />
-      <Body code={code} exportAsSuite={exportAsSuite} setExportAsSuite={setExportAsSuite} />
+      <Body code={code} exportAsProject={exportAsProject} setExportAsProject={setExportAsProject} />
       <Footer setVisible={setVisible} type={type} />
     </EuiFlyout>
   );

--- a/src/helpers/resultReducer.test.ts
+++ b/src/helpers/resultReducer.test.ts
@@ -25,7 +25,7 @@ THE SOFTWARE.
 import { resultReducer } from './resultReducer';
 
 describe('result reducer', () => {
-  it.each(['inline', 'suite'])('initializes result on journey start', type => {
+  it.each(['inline', 'project'])('initializes result on journey start', type => {
     expect(
       resultReducer(undefined, {
         event: 'journey/start',

--- a/src/hooks/useSyntheticsTest.ts
+++ b/src/hooks/useSyntheticsTest.ts
@@ -70,7 +70,7 @@ export function useSyntheticsTest(steps: RecorderSteps): ITestContext {
           const promise = ipc.callMain('run-journey', {
             steps,
             code,
-            isSuite: false,
+            isProject: false,
           });
           setIsTestInProgress(true);
           setIsResultFlyoutVisible(true);


### PR DESCRIPTION
closes #254 

## Summary
Aligning the usage of terminology within Synthetics product. We decided to use `Projects` instead of `Suites`.

Updated all the Suite usage both in code and visual contents so that we are not confused by deprecated terms in future development.