### PR TITLE
fix: Exports scripts as js file by setting filters for `dialog.showSaveDialog`

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -21,14 +21,21 @@ mac:
   icon: public/elastic.png
   category: public.app-category.developer-tools
   target:
-    target: default
-    arch: [x64, arm64]
+    - target: default
+      arch: 
+        - x64 
+        - arm64
 win:
-  target: nsis
+  target:
+    - target: nsis
+      arch:
+        - x64
   icon: public/elastic.png
 linux:
   target:
-    - deb
+    - target: deb
+      arch:
+        - x64
   icon: public/elastic.png
   category: Utility
   # electron-builder issue:

--- a/electron/execution.ts
+++ b/electron/execution.ts
@@ -23,7 +23,7 @@ THE SOFTWARE.
 */
 
 import { chromium } from 'playwright';
-import { join, resolve } from 'path';
+import { join, resolve, extname } from 'path';
 import { existsSync } from 'fs';
 import { writeFile, rm, mkdir } from 'fs/promises';
 import { ipcMain as ipc } from 'electron-better-ipc';
@@ -351,7 +351,8 @@ async function onFileSave(code: string) {
   });
 
   if (!canceled && filePath) {
-    await writeFile(filePath, code);
+    const validPath = extname(filePath) === '.js' ? filePath : filePath + '.js';
+    await writeFile(validPath, code);
     return true;
   }
   return false;

--- a/electron/execution.ts
+++ b/electron/execution.ts
@@ -23,7 +23,7 @@ THE SOFTWARE.
 */
 
 import { chromium } from 'playwright';
-import { join, resolve, extname } from 'path';
+import { join, resolve } from 'path';
 import { existsSync } from 'fs';
 import { writeFile, rm, mkdir } from 'fs/promises';
 import { ipcMain as ipc } from 'electron-better-ipc';
@@ -347,12 +347,17 @@ function onTest(mainWindowEmitter: EventEmitter) {
 async function onFileSave(code: string) {
   const window = BrowserWindow.getFocusedWindow() || BrowserWindow.getAllWindows()[0];
   const { filePath, canceled } = await dialog.showSaveDialog(window, {
+    filters: [
+      {
+        name: 'JavaScript',
+        extensions: ['js'],
+      },
+    ],
     defaultPath: 'recorded.journey.js',
   });
 
   if (!canceled && filePath) {
-    const validPath = extname(filePath) === '.js' ? filePath : filePath + '.js';
-    await writeFile(validPath, code);
+    await writeFile(filePath, code);
     return true;
   }
   return false;

--- a/src/components/SaveCodeButton.tsx
+++ b/src/components/SaveCodeButton.tsx
@@ -40,12 +40,14 @@ export function SaveCodeButton({ type }: ISaveCodeButton) {
   const { sendToast } = useContext(ToastContext);
   const onSave = async () => {
     const codeFromActions = await getCodeFromActions(ipc, steps, type);
-    await ipc.callMain('save-file', codeFromActions);
-    sendToast({
-      id: `file-export-${new Date().valueOf()}`,
-      title: 'Script export successful',
-      color: 'success',
-    });
+    const exported = await ipc.callMain('save-file', codeFromActions);
+    if (exported) {
+      sendToast({
+        id: `file-export-${new Date().valueOf()}`,
+        title: 'Script export successful',
+        color: 'success',
+      });
+    }
   };
   return (
     <EuiButton fill color="primary" iconType="exportAction" onClick={onSave}>


### PR DESCRIPTION
## Summary

- Resolves #276 
- Do not show _Script export successful_ toast when export is canceled

Use _filters_ option to specify js extension when saving the file with showSaveDialog.


## How to validate the fix
Record a test, click Export button and omit `.js` extension from the file name and save the file. Check the file is saved as js file automatically.

demo on Windows:

https://user-images.githubusercontent.com/16660866/185129419-4f1f1923-5a42-4d30-b7a7-858a0974a6ca.mov