### PR TITLE
fix: always wait for url when navigation is signaled

### DIFF
--- a/electron/__snapshots__/syntheticsGenerator.test.ts.snap
+++ b/electron/__snapshots__/syntheticsGenerator.test.ts.snap
@@ -19,7 +19,7 @@ journey('Recorded journey', async ({ page, context }) => {
       page.click('text=Babel Minify')
     ]);
     await Promise.all([
-      page1.waitForNavigation(),
+      page1.waitForNavigation({ url: 'https://github.com/babel/minify' }),
       page1.click('a:has-text(\\"smoke\\")')
     ]);
   });

--- a/electron/__snapshots__/syntheticsGenerator.test.ts.snap
+++ b/electron/__snapshots__/syntheticsGenerator.test.ts.snap
@@ -19,7 +19,7 @@ journey('Recorded journey', async ({ page, context }) => {
       page.click('text=Babel Minify')
     ]);
     await Promise.all([
-      page1.waitForNavigation(/*{ url: 'https://github.com/babel/minify' }*/),
+      page1.waitForNavigation(),
       page1.click('a:has-text(\\"smoke\\")')
     ]);
   });

--- a/electron/syntheticsGenerator.ts
+++ b/electron/syntheticsGenerator.ts
@@ -212,12 +212,7 @@ export class SyntheticsGenerator extends PlaywrightGenerator.JavaScriptLanguageG
     if (signals.popup) formatter.add(`${pageAlias}.waitForEvent('popup'),`);
 
     // Navigation signal.
-    if (signals.waitForNavigation)
-      formatter.add(
-        `${pageAlias}.waitForNavigation(/*{ url: ${quote(
-          signals.waitForNavigation.url ?? ''
-        )} }*/),`
-      );
+    if (signals.waitForNavigation) formatter.add(`${pageAlias}.waitForNavigation(),`);
 
     // Download signals.
     if (signals.download) formatter.add(`${pageAlias}.waitForEvent('download'),`);

--- a/electron/syntheticsGenerator.ts
+++ b/electron/syntheticsGenerator.ts
@@ -212,7 +212,10 @@ export class SyntheticsGenerator extends PlaywrightGenerator.JavaScriptLanguageG
     if (signals.popup) formatter.add(`${pageAlias}.waitForEvent('popup'),`);
 
     // Navigation signal.
-    if (signals.waitForNavigation) formatter.add(`${pageAlias}.waitForNavigation(),`);
+    if (signals.waitForNavigation)
+      formatter.add(
+        `${pageAlias}.waitForNavigation({ url: ${quote(signals.waitForNavigation.url ?? '')} }),`
+      );
 
     // Download signals.
     if (signals.download) formatter.add(`${pageAlias}.waitForEvent('download'),`);


### PR DESCRIPTION
## Summary

Removes the comment that gets added before the navigation action is recorded. 

## How to validate this change

Record a journey that includes URL navigation. Make sure that your JS output will run properly.