### PR TITLE
fix: allow editing value when editing `fill` action

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,4 +2,5 @@ build
 dist
 local-browsers
 demo-app
+coverage
 *.yml

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ You can find downloadable installers there for a variety of platforms.
 
 Download and unpack the appropriate installer for your platform, and install it.
 
-
 #### Usage
 
 This section describes the basic usage of the Script Recorder.
@@ -59,11 +58,13 @@ npm run dev
 ```
 
 #### Managing Playwright dependency
+
 When updating the version of [@elastic/synthetics](https://github.com/elastic/synthetics)(called _Synthetics agent_ hereafter), it is important to align the version of Playwright that the Synthetics agent uses and the forked Playwright that is installed by the recorder. Steps to update the Playwright is as followed:
 
 1. Go to [@elastic/playwright](https://github.com/elastic/playwright), fetch upstream microsoft:main into main if needed. We keep our modifications in `synthetics-recorder` branch. It is supposed to have only one extra commit[(84309bf)](https://github.com/elastic/playwright/commit/84309bf44d2a97889b178f2f2da2bc9f30e5aff8)) compared to the main branch. If main branch has new commits, fetch the changes into `synthetics-recorder` branch by pulling it with [rebase](https://git-scm.com/docs/git-pull#Documentation/git-pull.txt---rebasefalsetruemergesinteractive) option
 
 1. Pull the remote changes to your machine. If necessary, set the remote as follows:
+
 ```
 git remote add upstream https://github.com/microsoft/playwright.git
 git remote add elastic https://github.com/elastic/playwright.git
@@ -74,19 +75,25 @@ git remote -v
 // elastic  https://github.com/elastic/playwright.git (fetch)
 // elastic  https://github.com/elastic/playwright.git (push)
 ```
+
 2. Confirm the Playwright version from Synthetics agent's `package.json`:
+
 ```
 // @elastic/synthetics's package.json
 ...
     "playwright-core": "=1.20.1",
 ...
 ```
+
 3. Fetch the tags from upstream, checkout to the version 1.20.1, and create a new branch:
+
 ```
 git fetch upstream --tags
 git checkout -b 1.20.1-recorder v1.20.1
 ```
+
 4. Cherry-pick the commit from `synthetics-recorder` branch, then run `npm run build`. You should see generated js files under `packages/playwright-core/lib` directory. Commit all the changes and push it to elastic remote:
+
 ```
 git cherry-pick 84309bf
 # solve conflicts if necessary
@@ -94,7 +101,9 @@ npm run build
 git add .
 git push  --set-upstream elastic 1.20.1-recorder
 ```
+
 5. Test new changes in the Recorder by updating Recorder's package.json. Update `playwright` dependency to the branch you pushed from above step:
+
 ```js
 // @elastic/synthetics-recorder's package.json
 ...
@@ -103,6 +112,7 @@ git push  --set-upstream elastic 1.20.1-recorder
 ```
 
 For now, we are doing it all manually, However, we should consider automating the process.
+
 ### Build
 
 Build and Package the app for all platforms

--- a/src/components/ActionDetail/ActionDetail.test.tsx
+++ b/src/components/ActionDetail/ActionDetail.test.tsx
@@ -1,0 +1,56 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+import { fireEvent, getByRole } from '@testing-library/react';
+import React from 'react';
+import { createAction } from '../../../common/helper/test/createAction';
+import { ActionContext } from '../../../common/types';
+import { render } from '../../helpers/test';
+import { ActionDetail } from './ActionDetail';
+
+describe.only('<ActionDetail />', () => {
+  describe('navigate', () => {
+    const url = 'https://example.com';
+    const navigateAction = createAction('navigate', { action: { url } });
+
+    it('has url input', () => {
+      const { getByLabelText } = render(
+        <ActionDetail actionContext={navigateAction} actionIndex={0} stepIndex={0} />
+      );
+      const input = getByLabelText(/navigate/i);
+      expect(input).toBeTruthy();
+      expect(input.getAttribute('value')).toEqual(url);
+    });
+
+    it('updates input', () => {
+      const { getByLabelText, getByRole } = render(
+        <ActionDetail actionContext={navigateAction} actionIndex={0} stepIndex={0} />
+      );
+      const input = getByLabelText(/navigate/i);
+
+      fireEvent.change(input, { target: { value: 'https://elastic.co' } });
+      const button = getByRole('button', { name: /save/i });
+      fireEvent.click(button);
+    });
+  });
+});

--- a/src/components/ActionDetail/ActionDetail.test.tsx
+++ b/src/components/ActionDetail/ActionDetail.test.tsx
@@ -27,10 +27,16 @@ import { createAction } from '../../../common/helper/test/createAction';
 import { render } from '../../helpers/test';
 import { ActionDetail } from './ActionDetail';
 import { ActionContext } from '../../../common/types';
-import { IStepsContext, StepsContext } from '../../contexts/StepsContext';
-import { getStepsContextDefaults } from '../../helpers/test/defaults';
 
 describe('<ActionDetail />', () => {
+  let onUpdateActionMock: jest.Mock;
+
+  beforeEach(() => {
+    onUpdateActionMock = jest.fn(updatedAction => {
+      return updatedAction;
+    });
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
   });
@@ -52,23 +58,18 @@ describe('<ActionDetail />', () => {
     });
 
     it('updates url', () => {
-      const onUpdateActionMock = jest.fn(updatedAction => {
-        return updatedAction;
-      });
-      const { getByLabelText, getByRole } = renderWithStepsContext(
+      const { getByLabelText, getByRole } = render(
         <ActionDetail actionContext={navigateAction} actionIndex={0} stepIndex={0} />,
-        { onUpdateAction: onUpdateActionMock }
+        { contextOverrides: { steps: { onUpdateAction: onUpdateActionMock } } }
       );
       const input = getByLabelText(/navigate/i);
-
       const newUrl = 'https://elastic.co';
       fireEvent.change(input, { target: { value: newUrl } });
       const button = getByRole('button', { name: /save/i });
       fireEvent.click(button);
+
       expect(onUpdateActionMock).toHaveBeenCalled();
-      const {
-        value: { action },
-      } = onUpdateActionMock.mock.results[0];
+      const { action } = onUpdateActionMock.mock.results[0].value;
       expect(action.url).toEqual(newUrl);
     });
   });
@@ -89,12 +90,11 @@ describe('<ActionDetail />', () => {
     });
 
     it('updates selector', () => {
-      const onUpdateActionMock = jest.fn(updatedAction => {
-        return updatedAction;
-      });
-      const { getByLabelText, getByRole } = renderWithStepsContext(
+      const { getByLabelText, getByRole } = render(
         <ActionDetail actionContext={clickAction} actionIndex={0} stepIndex={0} />,
-        { onUpdateAction: onUpdateActionMock }
+        {
+          contextOverrides: { steps: { onUpdateAction: onUpdateActionMock } },
+        }
       );
       const input = getByLabelText(/click/i);
 
@@ -102,9 +102,7 @@ describe('<ActionDetail />', () => {
       const button = getByRole('button', { name: /save/i });
       fireEvent.click(button);
       expect(onUpdateActionMock).toHaveBeenCalled();
-      const {
-        value: { action },
-      } = onUpdateActionMock.mock.results[0];
+      const { action } = onUpdateActionMock.mock.results[0].value;
       expect(action.selector).toEqual('#new-elem-id');
     });
   });
@@ -131,12 +129,11 @@ describe('<ActionDetail />', () => {
     });
 
     it('updates selector and fill value', () => {
-      const onUpdateActionMock = jest.fn(updatedAction => {
-        return updatedAction;
-      });
-      const { getByLabelText, getByRole } = renderWithStepsContext(
+      const { getByLabelText, getByRole } = render(
         <ActionDetail actionContext={fillAction} actionIndex={0} stepIndex={0} />,
-        { onUpdateAction: onUpdateActionMock }
+        {
+          contextOverrides: { steps: { onUpdateAction: onUpdateActionMock } },
+        }
       );
       const selectorInput = getByLabelText(/fill/i);
       fireEvent.change(selectorInput, { target: { value: '#new-elem-id' } });
@@ -145,17 +142,11 @@ describe('<ActionDetail />', () => {
       fireEvent.change(valueInput, { target: { value: 'Elastic' } });
       const button = getByRole('button', { name: /save/i });
       fireEvent.click(button);
+
       expect(onUpdateActionMock).toHaveBeenCalled();
-      const {
-        value: { action },
-      } = onUpdateActionMock.mock.results[0];
+      const { action } = onUpdateActionMock.mock.results[0].value;
       expect(action.selector).toEqual('#new-elem-id');
       expect(action.text).toEqual('Elastic');
     });
   });
 });
-
-function renderWithStepsContext(childComp: React.ReactChild, overrides?: Partial<IStepsContext>) {
-  const value: IStepsContext = { ...getStepsContextDefaults(), ...overrides };
-  return render(<StepsContext.Provider value={value}>{childComp}</StepsContext.Provider>);
-}

--- a/src/components/ActionDetail/ActionDetail.tsx
+++ b/src/components/ActionDetail/ActionDetail.tsx
@@ -63,16 +63,9 @@ interface IActionDetail {
   actionIndex: number;
   stepIndex: number;
   close?: () => void;
-  update?: (action: ActionContext, stepIndex: number, actionIndex: number) => void;
 }
 
-export function ActionDetail({
-  actionContext,
-  actionIndex,
-  stepIndex,
-  close,
-  update,
-}: IActionDetail) {
+export function ActionDetail({ actionContext, actionIndex, stepIndex, close }: IActionDetail) {
   const { onUpdateAction } = useContext(StepsContext);
   const { action } = actionContext;
   const [selector, setSelector] = useState(action.selector || '');
@@ -87,8 +80,7 @@ export function ActionDetail({
       },
       actionContext
     );
-    const applyUpdate = update ?? onUpdateAction;
-    applyUpdate(updatedAction, stepIndex, actionIndex);
+    onUpdateAction(updatedAction, stepIndex, actionIndex);
   };
 
   return (
@@ -136,7 +128,7 @@ export function ActionDetail({
         <EuiFlexItem grow={false}>
           <EuiButton
             data-test-subj={`save-action-${stepIndex}-${actionIndex}`}
-            onClick={() => updateAction()}
+            onClick={updateAction}
           >
             Save
           </EuiButton>

--- a/src/components/ActionDetail/ActionDetail.tsx
+++ b/src/components/ActionDetail/ActionDetail.tsx
@@ -63,9 +63,16 @@ interface IActionDetail {
   actionIndex: number;
   stepIndex: number;
   close?: () => void;
+  update?: (action: ActionContext, stepIndex: number, actionIndex: number) => void;
 }
 
-export function ActionDetail({ actionContext, actionIndex, close, stepIndex }: IActionDetail) {
+export function ActionDetail({
+  actionContext,
+  actionIndex,
+  stepIndex,
+  close,
+  update,
+}: IActionDetail) {
   const { onUpdateAction } = useContext(StepsContext);
   const { action } = actionContext;
   const [selector, setSelector] = useState(action.selector || '');
@@ -80,7 +87,8 @@ export function ActionDetail({ actionContext, actionIndex, close, stepIndex }: I
       },
       actionContext
     );
-    onUpdateAction(updatedAction, stepIndex, actionIndex);
+    const applyUpdate = update ?? onUpdateAction;
+    applyUpdate(updatedAction, stepIndex, actionIndex);
   };
 
   return (

--- a/src/components/Header/HeaderControls.test.tsx
+++ b/src/components/Header/HeaderControls.test.tsx
@@ -35,29 +35,21 @@ describe('<HeaderControls />', () => {
   });
 
   it('displays pause text when recording', () => {
-    const { getByLabelText } = render(
-      <HeaderControls setIsCodeFlyoutVisible={jest.fn()} />,
-      undefined,
-      {
-        contextOverrides: {
-          recording: { recordingStatus: RecordingStatus.Recording },
-        },
-      }
-    );
+    const { getByLabelText } = render(<HeaderControls setIsCodeFlyoutVisible={jest.fn()} />, {
+      contextOverrides: {
+        recording: { recordingStatus: RecordingStatus.Recording },
+      },
+    });
 
     expect(getByLabelText('Pause')).toBeTruthy();
   });
 
   it('displays resume text when paused', () => {
-    const { getByLabelText } = render(
-      <HeaderControls setIsCodeFlyoutVisible={jest.fn()} />,
-      undefined,
-      {
-        contextOverrides: {
-          recording: { recordingStatus: RecordingStatus.Paused },
-        },
-      }
-    );
+    const { getByLabelText } = render(<HeaderControls setIsCodeFlyoutVisible={jest.fn()} />, {
+      contextOverrides: {
+        recording: { recordingStatus: RecordingStatus.Paused },
+      },
+    });
 
     expect(getByLabelText('Resume')).toBeTruthy();
   });

--- a/src/helpers/test/render.tsx
+++ b/src/helpers/test/render.tsx
@@ -39,8 +39,8 @@ import { RenderContexts } from './RenderContexts';
 
 export function render<ComponentType>(
   component: React.ReactElement<ComponentType>,
-  rtlRenderOptions?: Omit<RenderOptions, 'queries'>,
   options?: {
+    renderOptions?: Omit<RenderOptions, 'queries'>;
     contextOverrides?: {
       communication?: Partial<ICommunicationContext>;
       recording?: Partial<IRecordingContext>;
@@ -76,6 +76,6 @@ export function render<ComponentType>(
     <StyledComponentsEuiProvider>
       <RenderContexts contexts={contexts}>{component}</RenderContexts>
     </StyledComponentsEuiProvider>,
-    rtlRenderOptions
+    options?.renderOptions
   );
 }


### PR DESCRIPTION
fixes #282 

Allow editing `Value` field for the fill command.

#### How to validate the change
Record a journey that types some text in an input element. 
Locate the `fill` action and go to Edit action. Check that the Value input field is editable and the change is applied when clicking the `Save` button.
