### PR TITLE
fix: drop url when generating waitForNavigation code

### DIFF
--- a/electron/__snapshots__/syntheticsGenerator.test.ts.snap
+++ b/electron/__snapshots__/syntheticsGenerator.test.ts.snap
@@ -19,7 +19,7 @@ journey('Recorded journey', async ({ page, context }) => {
       page.locator('text=Babel Minify').click()
     ]);
     await Promise.all([
-      page1.waitForNavigation({ url: 'https://github.com/babel/minify' }),
+      page1.waitForNavigation(),
       page1.locator('a:has-text(\\"smoke\\")').click()
     ]);
   });

--- a/electron/syntheticsGenerator.ts
+++ b/electron/syntheticsGenerator.ts
@@ -213,10 +213,7 @@ export class SyntheticsGenerator extends PlaywrightGenerator.JavaScriptLanguageG
     if (signals.popup) formatter.add(`${pageAlias}.waitForEvent('popup'),`);
 
     // Navigation signal.
-    if (signals.waitForNavigation)
-      formatter.add(
-        `${pageAlias}.waitForNavigation({ url: ${quote(signals.waitForNavigation.url ?? '')} }),`
-      );
+    if (signals.waitForNavigation) formatter.add(`${pageAlias}.waitForNavigation(),`);
 
     // Download signals.
     if (signals.download) formatter.add(`${pageAlias}.waitForEvent('download'),`);


### PR DESCRIPTION
## Summary
Do not include `url` options when generating `waitForNavigation` function as it often contains cachebuster query params and the following Test run fails with navigation time error as it doesn't match the exact URL due to the mentioned query params.
<!-- If you have any screenshots or GIFs, here's where you should include them. -->

## How to validate this change
There were concerns about SPA not always yielding the navigation events, but this seems to be covered by:
1. [tests](https://github.com/microsoft/playwright/blob/main/tests/page/page-wait-for-navigation.spec.ts#L78) in Playwright showing `waitForNavigation` are supported for SPA
2. recorder doesn't seem to generate signal for SPA navigations which inturns never calls waitForNavigation  to be generated: 
![image](https://user-images.githubusercontent.com/16660866/185445451-175a4dfd-c4d1-40c7-9c69-b9ebba87e8f5.png)
