### PR TITLE
chore: notarize Mac applications

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -307,7 +307,7 @@ def runReleaseWithKeychain() {
   def token = getVaultSecret.getVaultToken(vault.vault_addr, vault.vault_role_id, vault.vault_secret_id)
   def apple = getVaultSecret.getVaultSecretObject(vault.vault_addr, 'secret/release/apple', token).data
   if (!apple.containsKey('keychain-password') || !apple.containsKey('username') || !apple.containsKey('app-specific-password')) {
-    error("runReleaseWithKeychain: apple secret must contain bundle-id, username, app-specific-password")
+    error("runReleaseWithKeychain: apple secret must contain username, app-specific-password")
   }
   withEnvMask(vars: [
     [var: 'KEYCHAIN_PASSWORD', password: apple.get('keychain-password')],

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -306,10 +306,14 @@ def runReleaseWithKeychain() {
   }
   def token = getVaultSecret.getVaultToken(vault.vault_addr, vault.vault_role_id, vault.vault_secret_id)
   def apple = getVaultSecret.getVaultSecretObject(vault.vault_addr, 'secret/release/apple', token).data
-  if (!apple.containsKey('keychain-password')) {
-    error("runReleaseWithKeychain: apple secret could not be accessed correctly")
+  if (!apple.containsKey('keychain-password') || !apple.containsKey('username') || !apple.containsKey('app-specific-password')) {
+    error("runReleaseWithKeychain: apple secret must contain bundle-id, username, app-specific-password")
   }
-  withEnvMask(vars: [[var: 'KEYCHAIN_PASSWORD', password: apple.get('keychain-password')]]){
+  withEnvMask(vars: [
+    [var: 'KEYCHAIN_PASSWORD', password: apple.get('keychain-password')],
+    [var: 'APPLE_USERNAME', password: apple.get('username')],
+    [var: 'APPLE_APP_SPECIFIC_PASSWORD', password: apple.get('app-specific-password')],
+  ]){
     sh(label: 'release-ci.sh', script: '.ci/scripts/release-ci.sh')
   }
 }

--- a/.ci/scripts/release-ci.sh
+++ b/.ci/scripts/release-ci.sh
@@ -18,4 +18,9 @@ security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$CSC_KEYCHAIN"
 echo 'run release-ci'
 set -x
 npm ci
+
+# temp, TEAM_ID is public info that is available in codesign verification
+export APPLE_TEAM_ID='2BT3HPN62Z'
+export APPLE_USERNAME
+export APPLE_APP_SPECIFIC_PASSWORD
 npm run release-ci

--- a/assets/entitlements.mac.plist
+++ b/assets/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/assets/entitlements.mac.plist
+++ b/assets/entitlements.mac.plist
@@ -4,8 +4,6 @@
   <dict>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -26,7 +26,6 @@ mac:
   entitlementsInherit: assets/entitlements.mac.plist
   gatekeeperAssess: false
   hardenedRuntime: true
-  provisioningProfile: Synthetics_Recorder.provisionprofile
   target:
     - target: default
       arch: 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -3,9 +3,11 @@ appId: co.elastic.synthetics-recorder
 artifactName: ${name}-${version}-${os}-${arch}.${ext}
 beforePack: "./scripts/before-pack.js"
 afterPack: "./scripts/after-pack.js"
+afterSign: "./scripts/notarize.js"
 files:
   - build/**/*
   - scripts/**/*
+  - assets/entitlements.mac.plist
 extraResources:
   - from: local-browsers/_releases/${os}-${arch}
     to: local-browsers
@@ -20,6 +22,11 @@ protocols:
 mac:
   icon: public/elastic.png
   category: public.app-category.developer-tools
+  entitlements: assets/entitlements.mac.plist
+  entitlementsInherit: assets/entitlements.mac.plist
+  gatekeeperAssess: false
+  hardenedRuntime: true
+  provisioningProfile: Synthetics_Recorder.provisionprofile
   target:
     - target: default
       arch: 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -26,6 +26,7 @@ mac:
   entitlementsInherit: assets/entitlements.mac.plist
   gatekeeperAssess: false
   hardenedRuntime: true
+  # provisioningProfile: Synthetics_Recorder.provisionprofile
   target:
     - target: default
       arch: 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -26,7 +26,6 @@ mac:
   entitlementsInherit: assets/entitlements.mac.plist
   gatekeeperAssess: false
   hardenedRuntime: true
-  # provisioningProfile: Synthetics_Recorder.provisionprofile
   target:
     - target: default
       arch: 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "synthetics-recorder",
-  "version": "0.0.1-beta.6",
+  "version": "0.0.1-notarization.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "synthetics-recorder",
-      "version": "0.0.1-beta.6",
+      "version": "0.0.1-notarization.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "synthetics-recorder",
-  "version": "0.0.1-notarization.3",
+  "version": "0.0.1-beta.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "synthetics-recorder",
-      "version": "0.0.1-notarization.3",
+      "version": "0.0.1-beta.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "concurrently": "^7.2.2",
         "electron": "^20.0.2",
         "electron-builder": "^23.3.1",
+        "electron-notarize": "^1.2.1",
         "eslint": "^8.19.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-header": "^3.1.1",
@@ -9353,6 +9354,55 @@
       "version": "4.4.8",
       "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.4.8.tgz",
       "integrity": "sha512-QQ4GvrXO+HkgqqEOYbi+DHL7hj5JM+nHi/j+qrN9zeeXVKy8ZABgbu4CnG+BBqDZ2+tbeq9tUC4DZfIWFU5AZA=="
+    },
+    "node_modules/electron-notarize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.2.1.tgz",
+      "integrity": "sha512-u/ECWhIrhkSQpZM4cJzVZ5TsmkaqrRo5LDC/KMbGF0sPkm53Ng59+M0zp8QVaql0obfJy9vlVT+4iOkAi2UDlA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-notarize/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-notarize/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-notarize/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/electron-osx-sign": {
       "version": "0.6.0",
@@ -33650,6 +33700,46 @@
       "version": "4.4.8",
       "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.4.8.tgz",
       "integrity": "sha512-QQ4GvrXO+HkgqqEOYbi+DHL7hj5JM+nHi/j+qrN9zeeXVKy8ZABgbu4CnG+BBqDZ2+tbeq9tUC4DZfIWFU5AZA=="
+    },
+    "electron-notarize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.2.1.tgz",
+      "integrity": "sha512-u/ECWhIrhkSQpZM4cJzVZ5TsmkaqrRo5LDC/KMbGF0sPkm53Ng59+M0zp8QVaql0obfJy9vlVT+4iOkAi2UDlA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
+      }
     },
     "electron-osx-sign": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "concurrently": "^7.2.2",
     "electron": "^20.0.2",
     "electron-builder": "^23.3.1",
+    "electron-notarize": "^1.2.1",
     "eslint": "^8.19.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-header": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synthetics-recorder",
-  "version": "0.0.1-notarization.3",
+  "version": "0.0.1-beta.6",
   "description": "Record synthetics user journey flow of a website",
   "repository": "https://github.com/elastic/synthetics-recorder",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synthetics-recorder",
-  "version": "0.0.1-beta.6",
+  "version": "0.0.1-notarization.3",
   "description": "Record synthetics user journey flow of a website",
   "repository": "https://github.com/elastic/synthetics-recorder",
   "scripts": {

--- a/scripts/before-pack.js
+++ b/scripts/before-pack.js
@@ -32,13 +32,19 @@ exports.default = function beforePack(ctx) {
 };
 
 function fixSharp(platform, arch) {
+  const filteredEnvs = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (!k.startsWith('APPLE_') && !k.includes('PASSWORD')) {
+      filteredEnvs[k] = v;
+    }
+  }
+
   return new Promise((resolve, reject) => {
     const npmInstall = spawn('npm', ['run', 'fix-sharp'], {
       stdio: 'inherit',
       shell: true,
       env: {
-        ...process.env,
-        KEYCHAIN_PASSWORD: undefined,
+        ...filteredEnvs,
         npm_config_arch: arch,
         npm_config_platform: platform,
       },

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -36,7 +36,7 @@ exports.default = async function notarizing(context) {
     tool: 'notarytool',
     appPath: `${appOutDir}/${appName}.app`,
     appBundleId: 'co.elastic.synthetics-recorder',
-    keychain: process.env.$CSC_KEYCHAIN,
-    keychainProfile: process.env.$KEYCHAIN_PASSWORD,
+    keychain: process.env.CSC_KEYCHAIN,
+    keychainProfile: process.env.KEYCHAIN_PASSWORD,
   });
 };

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -28,15 +28,15 @@ exports.default = async function notarizing(context) {
   if (electronPlatformName !== 'darwin') {
     return;
   }
-
   const appName = context.packager.appInfo.productFilename;
-
   console.log('Uploading app to notarization server...');
+  const { APPLE_USERNAME, APPLE_TEAM_ID, APPLE_APP_SPECIFIC_PASSWORD } = process.env;
+
   return await notarize({
     tool: 'notarytool',
     appPath: `${appOutDir}/${appName}.app`,
-    appBundleId: 'co.elastic.synthetics-recorder',
-    keychain: process.env.CSC_KEYCHAIN,
-    keychainProfile: process.env.KEYCHAIN_PASSWORD,
+    appleId: APPLE_USERNAME,
+    appleIdPassword: APPLE_APP_SPECIFIC_PASSWORD,
+    teamId: APPLE_TEAM_ID,
   });
 };

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -1,0 +1,42 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+const { notarize } = require('electron-notarize');
+
+exports.default = async function notarizing(context) {
+  const { electronPlatformName, appOutDir } = context;
+  if (electronPlatformName !== 'darwin') {
+    return;
+  }
+
+  const appName = context.packager.appInfo.productFilename;
+
+  console.log('Uploading app to notarization server...');
+  return await notarize({
+    tool: 'notarytool',
+    appPath: `${appOutDir}/${appName}.app`,
+    appBundleId: 'co.elastic.synthetics-recorder',
+    keychain: process.env.$CSC_KEYCHAIN,
+    keychainProfile: process.env.$KEYCHAIN_PASSWORD,
+  });
+};


### PR DESCRIPTION
closes #51 

## Summary
Notarize Mac applications so that the users can use the app without worrying about malicious code.

This PR introduces [electron-notarize](https://github.com/electron/electron-notarize) module to notarize the app and it is used when the Electron builder's `afterSign` hook is called. It is a recommended by electron-builder maintainers.

## How to validate the change
After the artefacts are released, download them, and run the following commands to verify the app has been notarized.

(Artifacts generated from this branch can be found [here](https://github.com/elastic/synthetics-recorder/releases/tag/untagged-053cedd0e62b7b3b9d3f))

- Validate the app is notarized(should see _source=**Notarized Developer ID**_):
```
❯ spctl -a -t exec -vv $PATH_TO_APP/Elastic Synthetics Recorder.app
$PATH_TO_APP//Elastic Synthetics Recorder.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Elasticsearch, Inc (2BT3HPN62Z)
```

- Check the ticket is stapled(should see **_The validate action worked!_**):
```
❯ xcrun stapler validate $PATH_TO_APP/Elastic Synthetics Recorder.app
Processing: $PATH_TO_APP/Elastic Synthetics Recorder.app
The validate action worked!
```
- When opening the app, the warning message _Elastic Synthetics Recorder" can't be opened because Apple cannot check it for malicious software_ shouldn't be shown, instead, the message could be something like this:
<img alt="image" src=https://user-images.githubusercontent.com/16660866/192452572-36d706f7-e9f9-47b7-a133-ae9ab05c229a.png width="400" >


#### Checklist
I've check above points for all the artifacts below
- [x] arm64.dmg (after installing)
- [x] arm64.zip
- [x] x64.dmg (after installing)
- [x] x64.zip

