### PR TITLE
docker: use node docker images, mount volume and use node user

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -133,8 +133,9 @@ pipeline {
       }
       steps {
         withGithubNotify(context: "Test") {
+          deleteDir()
+          unstash 'source'
           dir("${BASE_DIR}"){
-            // NOTE: It uses the current workspace that was configured with npm ci
             sh(label: 'run tests', script: '.ci/scripts/run-test-in-docker.sh')
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -47,7 +47,8 @@ pipeline {
       options { skipDefaultCheckout() }
       when {
         beforeAgent true
-        expression { return !isTag() }
+        //expression { return !isTag() }
+        expression { return false }
       }
       steps {
         withGithubNotify(context: "Install") {
@@ -63,7 +64,8 @@ pipeline {
       options { skipDefaultCheckout() }
       when {
         beforeAgent true
-        expression { return !isTag() }
+        //expression { return !isTag() }
+        expression { return false }
       }
       steps {
         withGithubNotify(context: "Lint") {
@@ -92,7 +94,8 @@ pipeline {
       options { skipDefaultCheckout() }
       when {
         beforeAgent true
-        expression { return !isTag() }
+        //expression { return !isTag() }
+        expression { return false }
       }
       steps {
         withGithubNotify(context: "Build") {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -47,8 +47,7 @@ pipeline {
       options { skipDefaultCheckout() }
       when {
         beforeAgent true
-        //expression { return !isTag() }
-        expression { return false }
+        expression { return !isTag() }
       }
       steps {
         withGithubNotify(context: "Install") {
@@ -64,8 +63,7 @@ pipeline {
       options { skipDefaultCheckout() }
       when {
         beforeAgent true
-        //expression { return !isTag() }
-        expression { return false }
+        expression { return !isTag() }
       }
       steps {
         withGithubNotify(context: "Lint") {
@@ -94,8 +92,7 @@ pipeline {
       options { skipDefaultCheckout() }
       when {
         beforeAgent true
-        //expression { return !isTag() }
-        expression { return false }
+        expression { return !isTag() }
       }
       steps {
         withGithubNotify(context: "Build") {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -133,9 +133,8 @@ pipeline {
       }
       steps {
         withGithubNotify(context: "Test") {
-          deleteDir()
-          unstash 'source'
           dir("${BASE_DIR}"){
+            // NOTE: It uses the current workspace that was configured with npm ci
             sh(label: 'run tests', script: '.ci/scripts/run-test-in-docker.sh')
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -116,8 +116,8 @@ pipeline {
       steps {
         withGithubNotify(context: 'Docker Build') {
           dir("${BASE_DIR}"){
-            sh(label: 'docker build', script: ".ci/scripts/docker-build.sh")
             dockerLogin(secret: "${DOCKER_ELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
+            sh(label: 'docker build', script: ".ci/scripts/docker-build.sh")
             retryWithSleep(retries: 3, seconds: 5, backoff: true){
               sh(label: 'docker push', script: ".ci/scripts/docker-push.sh")
             }

--- a/.ci/scripts/docker-build.sh
+++ b/.ci/scripts/docker-build.sh
@@ -14,4 +14,5 @@ docker \
   --file e2e/Dockerfile.jenkins \
   --build-arg DISPLAY=":99" \
   --build-arg NODE_VERSION="${NODE_VERSION}" \
+  --build-arg UID="$UID" \
   --tag docker.elastic.co/observability-ci/synthetics-recorder:$TAG .

--- a/.ci/scripts/docker-build.sh
+++ b/.ci/scripts/docker-build.sh
@@ -3,8 +3,12 @@ set -eox pipefail
 
 TAG=${BRANCH_NAME:-'latest'}
 
+# Read node version from .nvmrc and remove v prefix.
+NODE_VERSION=$(cat .nvmrc | sed "s#v##g")
+
 docker \
   build \
   --file e2e/Dockerfile.jenkins \
   --build-arg DISPLAY=":99" \
+  --build-arg NODE_VERSION="${NODE_VERSION}" \
   --tag docker.elastic.co/observability-ci/synthetics-recorder:$TAG .

--- a/.ci/scripts/docker-build.sh
+++ b/.ci/scripts/docker-build.sh
@@ -6,6 +6,9 @@ TAG=${BRANCH_NAME:-'latest'}
 # Read node version from .nvmrc and remove v prefix.
 NODE_VERSION=$(cat .nvmrc | sed "s#v##g")
 
+# Download the docker image if possible
+docker pull docker.elastic.co/observability-ci/synthetics-recorder:$TAG || true
+
 docker \
   build \
   --file e2e/Dockerfile.jenkins \

--- a/.ci/scripts/run-test-in-docker.sh
+++ b/.ci/scripts/run-test-in-docker.sh
@@ -23,6 +23,7 @@ fi
 docker run \
   $DOCKER_RUN_OPTIONS \
   -u '0:0' \
+  -v "$(pwd):/synthetics-recorder" \
   -e NPM_COMMAND=${1:-''} \
   $DOCKER_IMAGE \
   .ci/scripts/run-test.sh

--- a/.ci/scripts/run-test-in-docker.sh
+++ b/.ci/scripts/run-test-in-docker.sh
@@ -22,7 +22,6 @@ fi
 # shellcheck disable=SC2086
 docker run \
   $DOCKER_RUN_OPTIONS \
-  --user node \
   -v "$(pwd):/synthetics-recorder" \
   -e NPM_COMMAND=${1:-'ci'} \
   $DOCKER_IMAGE \

--- a/.ci/scripts/run-test-in-docker.sh
+++ b/.ci/scripts/run-test-in-docker.sh
@@ -24,6 +24,6 @@ docker run \
   $DOCKER_RUN_OPTIONS \
   -u '0:0' \
   -v "$(pwd):/synthetics-recorder" \
-  -e NPM_COMMAND=${1:-''} \
+  -e NPM_COMMAND=${1:-'ci'} \
   $DOCKER_IMAGE \
   .ci/scripts/run-test.sh

--- a/.ci/scripts/run-test-in-docker.sh
+++ b/.ci/scripts/run-test-in-docker.sh
@@ -22,6 +22,8 @@ fi
 # shellcheck disable=SC2086
 docker run \
   $DOCKER_RUN_OPTIONS \
+  --user node \
+  -v ~/.npmrc:/home/node/.npmrc \
   -v "$(pwd):/synthetics-recorder" \
   -e NPM_COMMAND=${1:-'ci'} \
   $DOCKER_IMAGE \

--- a/.ci/scripts/run-test-in-docker.sh
+++ b/.ci/scripts/run-test-in-docker.sh
@@ -22,7 +22,6 @@ fi
 # shellcheck disable=SC2086
 docker run \
   $DOCKER_RUN_OPTIONS \
-  -u '0:0' \
   -v "$(pwd):/synthetics-recorder" \
   -e NPM_COMMAND=${1:-'ci'} \
   $DOCKER_IMAGE \

--- a/.ci/scripts/run-test-in-docker.sh
+++ b/.ci/scripts/run-test-in-docker.sh
@@ -23,6 +23,6 @@ fi
 docker run \
   $DOCKER_RUN_OPTIONS \
   -v "$(pwd):/synthetics-recorder" \
-  -e NPM_COMMAND=${1:-'ci'} \
+  -e NPM_COMMAND=${1:-''} \
   $DOCKER_IMAGE \
   .ci/scripts/run-test.sh

--- a/.ci/scripts/run-test-in-docker.sh
+++ b/.ci/scripts/run-test-in-docker.sh
@@ -23,7 +23,6 @@ fi
 docker run \
   $DOCKER_RUN_OPTIONS \
   --user node \
-  -v ~/.npmrc:/home/node/.npmrc \
   -v "$(pwd):/synthetics-recorder" \
   -e NPM_COMMAND=${1:-'ci'} \
   $DOCKER_IMAGE \

--- a/.ci/scripts/run-test.sh
+++ b/.ci/scripts/run-test.sh
@@ -7,6 +7,8 @@ set -x
 
 # If NPM_COMMAND then run it.
 if [ -n "${NPM_COMMAND}" ] ; then
+  # Fix [Error: EACCES: permission denied, mkdir '/synthetics-recorder/node_modules']
+  npm config set prefix --global $HOME/node_modules
   npm ${NPM_COMMAND}
 fi
 NPM_CONFIG_LOGLEVEL=verbose npm run test

--- a/.ci/scripts/run-test.sh
+++ b/.ci/scripts/run-test.sh
@@ -11,10 +11,6 @@ echo $USERNAME
 set -x
 # If NPM_COMMAND then run it.
 if [ -n "${NPM_COMMAND}" ] ; then
-  # Change the path otherwise it will fail in docker as it tries to
-  # to use /root/.npm
-  mkdir -p /synthetics-recorder/.npm || true
-  npm config --global set prefix /synthetics-recorder/.npm
   npm ${NPM_COMMAND}
 fi
 NPM_CONFIG_LOGLEVEL=verbose npm run test

--- a/.ci/scripts/run-test.sh
+++ b/.ci/scripts/run-test.sh
@@ -11,6 +11,10 @@ echo $USERNAME
 set -x
 # If NPM_COMMAND then run it.
 if [ -n "${NPM_COMMAND}" ] ; then
+  # Change the path otherwise it will fail in docker as it tries to
+  # to use /root/.npm
+  mkdir -p /synthetics-recorder/.npm || true
+  npm config --global set prefix /synthetics-recorder/.npm
   npm ${NPM_COMMAND}
 fi
 NPM_CONFIG_LOGLEVEL=verbose npm run test

--- a/.ci/scripts/run-test.sh
+++ b/.ci/scripts/run-test.sh
@@ -5,17 +5,8 @@ Xvfb ${DISPLAY} -screen 0 1024x768x16 &
 
 set -x
 
-# For debugging purposes
-whoami
-pwd
-echo $HOME
-ls -ltra $HOME
-
 # If NPM_COMMAND then run it.
 if [ -n "${NPM_COMMAND}" ] ; then
-  # for some reason this folder got permission denied when
-  # running on the CI workers Installation error: EACCES: permission denied
-  mkdir -p $HOME/.npm || true
   npm ${NPM_COMMAND}
 fi
 NPM_CONFIG_LOGLEVEL=verbose npm run test

--- a/.ci/scripts/run-test.sh
+++ b/.ci/scripts/run-test.sh
@@ -5,8 +5,6 @@ Xvfb ${DISPLAY} -screen 0 1024x768x16 &
 
 set -x
 
-ls -ltra
-
 # If NPM_COMMAND then run it.
 if [ -n "${NPM_COMMAND}" ] ; then
   npm ${NPM_COMMAND}

--- a/.ci/scripts/run-test.sh
+++ b/.ci/scripts/run-test.sh
@@ -5,10 +5,10 @@ Xvfb ${DISPLAY} -screen 0 1024x768x16 &
 
 set -x
 
+ls -ltra
+
 # If NPM_COMMAND then run it.
 if [ -n "${NPM_COMMAND}" ] ; then
-  # Fix [Error: EACCES: permission denied, mkdir '/synthetics-recorder/node_modules']
-  npm config set prefix --global $HOME/node_modules
   npm ${NPM_COMMAND}
 fi
 NPM_CONFIG_LOGLEVEL=verbose npm run test

--- a/.ci/scripts/run-test.sh
+++ b/.ci/scripts/run-test.sh
@@ -3,14 +3,19 @@ set -eo pipefail
 
 Xvfb ${DISPLAY} -screen 0 1024x768x16 &
 
-echo $UID
-echo $GID
-echo $USER
-echo $USERNAME
-
 set -x
+
+# For debugging purposes
+whoami
+pwd
+echo $HOME
+ls -ltra $HOME
+
 # If NPM_COMMAND then run it.
 if [ -n "${NPM_COMMAND}" ] ; then
+  # for some reason this folder got permission denied when
+  # running on the CI workers Installation error: EACCES: permission denied
+  mkdir -p $HOME/.npm || true
   npm ${NPM_COMMAND}
 fi
 NPM_CONFIG_LOGLEVEL=verbose npm run test

--- a/.ci/scripts/run-test.sh
+++ b/.ci/scripts/run-test.sh
@@ -8,8 +8,6 @@ echo $GID
 echo $USER
 echo $USERNAME
 
-source $NVM_DIR/nvm.sh
-nvm use
 set -x
 # If NPM_COMMAND then run it.
 if [ -n "${NPM_COMMAND}" ] ; then

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ eslint-junit.xml
 *-junit.xml
 .DS_Store
 tsconfig.tsbuildinfo
+
+.npm

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,3 @@ eslint-junit.xml
 *-junit.xml
 .DS_Store
 tsconfig.tsbuildinfo
-
-.npm

--- a/e2e/Dockerfile.jenkins
+++ b/e2e/Dockerfile.jenkins
@@ -1,7 +1,5 @@
-FROM ubuntu:20.04
-
-# Setting bash as the default shell
-RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+ARG NODE_VERSION=16.15.0
+FROM node:$NODE_VERSION-buster
 
 # Get desired XVFB display
 ARG DISPLAY
@@ -30,11 +28,3 @@ ENV DISPLAY $DISPLAY
 ENV NPM_COMMAND ci
 
 WORKDIR /synthetics-recorder
-# Copy .nvmrc as long as you run the script in .ci/scripts/docker-build.sh
-ADD .nvmrc /synthetics-recorder/.nvmrc
-
-# Installing NVM
-ENV NVM_DIR /root
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
-RUN source "${NVM_DIR}/nvm.sh" --install \
-  && nvm use

--- a/e2e/Dockerfile.jenkins
+++ b/e2e/Dockerfile.jenkins
@@ -29,13 +29,12 @@ RUN apt-get -y -qq install xvfb \
 ENV DISPLAY $DISPLAY
 ENV NPM_COMMAND ci
 
-COPY . ./synthetics-recorder
 WORKDIR /synthetics-recorder
 # Copy .nvmrc as long as you run the script in .ci/scripts/docker-build.sh
-# ADD .nvmrc /synthetics-recorder/.nvmrc
+ADD .nvmrc /synthetics-recorder/.nvmrc
 
 # Installing NVM
 ENV NVM_DIR /root
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 RUN source "${NVM_DIR}/nvm.sh" --install \
-  && nvm use && npm ci
+  && nvm install $(cat .nvmrc) && nvm use $(cat .nvmrc) && npm ci

--- a/e2e/Dockerfile.jenkins
+++ b/e2e/Dockerfile.jenkins
@@ -37,4 +37,4 @@ ADD .nvmrc /synthetics-recorder/.nvmrc
 ENV NVM_DIR /root
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 RUN source "${NVM_DIR}/nvm.sh" --install \
-  && nvm install $(cat .nvmrc) && nvm use $(cat .nvmrc)
+  && nvm use

--- a/e2e/Dockerfile.jenkins
+++ b/e2e/Dockerfile.jenkins
@@ -26,5 +26,6 @@ RUN apt-get -y -qq install xvfb \
 # Make relevant environment variables available for tests
 ENV DISPLAY $DISPLAY
 ENV NPM_COMMAND ci
+ENV NPM_CONFIG_PREFIX=/synthetics-recorder/.npm
 
 WORKDIR /synthetics-recorder

--- a/e2e/Dockerfile.jenkins
+++ b/e2e/Dockerfile.jenkins
@@ -29,6 +29,6 @@ ENV NPM_COMMAND ci
 
 WORKDIR /synthetics-recorder
 
-# Avoid issues with permissions if running as root
-ENV NPM_CONFIG_PREFIX=/synthetics-recorder/.npm
-ENV PATH=$PATH:/synthetics-recorder/.npm/bin
+USER node
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=$PATH:/home/node/.npm-global/bin

--- a/e2e/Dockerfile.jenkins
+++ b/e2e/Dockerfile.jenkins
@@ -1,5 +1,5 @@
 ARG NODE_VERSION=16.15.0
-FROM node:$NODE_VERSION-buster
+FROM node:$NODE_VERSION
 
 # Get desired XVFB display
 ARG DISPLAY

--- a/e2e/Dockerfile.jenkins
+++ b/e2e/Dockerfile.jenkins
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=16.15.0
+ARG NODE_VERSION
 FROM node:$NODE_VERSION
 
 # Get desired XVFB display

--- a/e2e/Dockerfile.jenkins
+++ b/e2e/Dockerfile.jenkins
@@ -29,6 +29,8 @@ ENV NPM_COMMAND ci
 
 WORKDIR /synthetics-recorder
 
+# Change the UID to match the one running the docker container
+ARG UID
+RUN usermod -u $UID node
+
 USER node
-ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
-ENV PATH=$PATH:/home/node/.npm-global/bin

--- a/e2e/Dockerfile.jenkins
+++ b/e2e/Dockerfile.jenkins
@@ -26,6 +26,9 @@ RUN apt-get -y -qq install xvfb \
 # Make relevant environment variables available for tests
 ENV DISPLAY $DISPLAY
 ENV NPM_COMMAND ci
-ENV NPM_CONFIG_PREFIX=/synthetics-recorder/.npm
 
 WORKDIR /synthetics-recorder
+
+# Avoid issues with permissions if running as root
+ENV NPM_CONFIG_PREFIX=/synthetics-recorder/.npm
+ENV PATH=$PATH:/synthetics-recorder/.npm/bin

--- a/e2e/Dockerfile.jenkins
+++ b/e2e/Dockerfile.jenkins
@@ -37,4 +37,4 @@ ADD .nvmrc /synthetics-recorder/.nvmrc
 ENV NVM_DIR /root
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 RUN source "${NVM_DIR}/nvm.sh" --install \
-  && nvm install $(cat .nvmrc) && nvm use $(cat .nvmrc) && npm ci
+  && nvm install $(cat .nvmrc) && nvm use $(cat .nvmrc)


### PR DESCRIPTION
## Summary

Revert partially https://github.com/elastic/synthetics-recorder/commit/5c91e170eded3f950443529bfdd7fe7f738100cc so it can mount the volume

## Implementation details

There are some issues while using the docker build with a docker copy entry since the workspace is stored hence it can cause other issues related to what's the workspace used for testing.

By reverting https://github.com/elastic/synthetics-recorder/commit/5c91e170eded3f950443529bfdd7fe7f738100cc , restoring the workspace, setting the uid and using the node docker images things should be back to normal.

## How to validate this change

It runs successfully in the CI

or 

```bash
$ .ci/scripts/docker-build.sh
$ .ci/scripts/run-test-in-docker.sh
```
