### PR TITLE
fix: import correct module for notarizing

### DIFF
--- a/.ci/scripts/run-test-in-docker.sh
+++ b/.ci/scripts/run-test-in-docker.sh
@@ -12,7 +12,7 @@ if [[ "$(docker images -q $DOCKER_IMAGE 2> /dev/null)" == "" ]]; then
   fi
 fi
 
-DOCKER_RUN_OPTIONS="-i --rm"
+DOCKER_RUN_OPTIONS="-u $(id -u):$(id -g) -i --rm"
 
 # Only allocate tty if we detect one
 if [ -t 0 ] && [ -t 1 ]; then

--- a/.ci/scripts/run-test-in-docker.sh
+++ b/.ci/scripts/run-test-in-docker.sh
@@ -12,7 +12,7 @@ if [[ "$(docker images -q $DOCKER_IMAGE 2> /dev/null)" == "" ]]; then
   fi
 fi
 
-DOCKER_RUN_OPTIONS="-u $(id -u):$(id -g) -i --rm"
+DOCKER_RUN_OPTIONS="-i --rm"
 
 # Only allocate tty if we detect one
 if [ -t 0 ] && [ -t 1 ]; then

--- a/scripts/download-chromium.js
+++ b/scripts/download-chromium.js
@@ -26,7 +26,7 @@ require('dotenv').config();
 
 const util = require('util');
 const path = require('path');
-const { downloadBrowserWithProgressBar } = require('playwright/lib/utils/browserFetcher');
+const { downloadBrowserWithProgressBar } = require('playwright/lib/server/registry/browserFetcher');
 const { getChromeVersion } = require('./install-pw');
 
 const EXECUTABLE_PATHS = {

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-const { notarize } = require('electron-notarize');
+const { notarize } = require('@electron/notarize');
 
 exports.default = async function notarizing(context) {
   const { electronPlatformName, appOutDir } = context;


### PR DESCRIPTION
Recently updated `electron-notarize` module to recommended `@electron/notarize`, but forgot to update the module name where it's used.

Also fixed one of the functions that has been moved to a different path.