### PR TITLE
test: try running tests on github action

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -104,47 +104,6 @@ pipeline {
         }
       }
     }
-    stage('Docker build') {
-      options { skipDefaultCheckout() }
-      when {
-        beforeAgent true
-        anyOf {
-          expression { env.DOCKER_CHANGES == 'true' }
-          expression { return env.GITHUB_COMMENT?.contains('all') }
-        }
-      }
-      steps {
-        withGithubNotify(context: 'Docker Build') {
-          dir("${BASE_DIR}"){
-            dockerLogin(secret: "${DOCKER_ELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
-            sh(label: 'docker build', script: ".ci/scripts/docker-build.sh")
-            retryWithSleep(retries: 3, seconds: 5, backoff: true){
-              sh(label: 'docker push', script: ".ci/scripts/docker-push.sh")
-            }
-          }
-        }
-      }
-    }
-    stage('Test'){
-      options { skipDefaultCheckout() }
-      when {
-        beforeAgent true
-        expression { return !isTag() }
-      }
-      steps {
-        withGithubNotify(context: "Test") {
-          dir("${BASE_DIR}"){
-            // NOTE: It uses the current workspace that was configured with npm ci
-            sh(label: 'run tests', script: '.ci/scripts/run-test-in-docker.sh')
-          }
-        }
-      }
-      post {
-        always {
-          junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/*junit.xml")
-        }
-      }
-    }
     stage('Release') {
       options { skipDefaultCheckout() }
       when {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -43,67 +43,6 @@ pipeline {
         }
       }
     }
-    stage('Install') {
-      options { skipDefaultCheckout() }
-      when {
-        beforeAgent true
-        expression { return !isTag() }
-      }
-      steps {
-        withGithubNotify(context: "Install") {
-          withNodeJSEnv() {
-            dir("${BASE_DIR}") {
-              sh(label: 'npm ci', script: 'npm ci')
-            }
-          }
-        }
-      }
-    }
-    stage('Lint') {
-      options { skipDefaultCheckout() }
-      when {
-        beforeAgent true
-        expression { return !isTag() }
-      }
-      steps {
-        withGithubNotify(context: "Lint") {
-          withNodeJSEnv() {
-            dir("${BASE_DIR}"){
-              sh(label: 'npm lint', script: 'npm run lint')
-            }
-          }
-        }
-        withGithubNotify(context: "Unused exports") {
-          withNodeJSEnv() {
-            dir("${BASE_DIR}"){
-              sh(label: 'npm unused-exports', script: 'npm run unused-exports')
-            }
-          }
-        }
-      }
-      post {
-        always {
-          archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/eslint-junit.xml")
-          junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/eslint-junit.xml")
-        }
-      }
-    }
-    stage('Build'){
-      options { skipDefaultCheckout() }
-      when {
-        beforeAgent true
-        expression { return !isTag() }
-      }
-      steps {
-        withGithubNotify(context: "Build") {
-          withNodeJSEnv() {
-            dir("${BASE_DIR}"){
-              sh(label: 'npm build', script: 'npm run build')
-            }
-          }
-        }
-      }
-    }
     stage('Release') {
       options { skipDefaultCheckout() }
       when {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
-name: Run Test
+name: Test
+
 on:
   push:
     branches:
@@ -8,6 +9,7 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+
 jobs:
   test:
     runs-on: macos-latest

--- a/.github/workflows/hello.yml
+++ b/.github/workflows/hello.yml
@@ -1,9 +1,0 @@
-name: hello-world
-
-on: workflow_dispatch
-
-jobs:
-  hello:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Hello, World!"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,4 @@
 name: Test
-
 on:
   push:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,13 @@
 name: Run Test
-on: 
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
   pull_request:
-    types:
-      - opened
+    paths-ignore:
+      - '**.md'
 jobs:
   test:
     runs-on: macos-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Lint
         run: npm run lint
       - name: Unused exports
-        run: npm unused-exports
+        run: npm run unused-exports
       - name: Build
         run: npm run build
       - name: Run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Run Test
+on: push
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cache deps
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install modules
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Run test
+        run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Run Test
-on: push
+on: 
+  pull_request:
+    types:
+      - opened
 jobs:
   test:
     runs-on: macos-latest
@@ -11,6 +14,10 @@ jobs:
           cache: 'npm'
       - name: Install modules
         run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Unused exports
+        run: npm unused-exports
       - name: Build
         run: npm run build
       - name: Run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,17 +5,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Cache deps
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
+      - uses: actions/setup-node@v3
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          node-version: 16.15.0
+          cache: 'npm'
       - name: Install modules
         run: npm ci
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.15.0
+          node-version-file: '.nvmrc'
           cache: 'npm'
       - name: Install modules
         run: npm ci


### PR DESCRIPTION
## Summary
Use github actions for `Test` step to simplify the process and reduce the maintenance burden

## Implementation details
We have had many issues with the testing environment in the past year, often caused by npm changing its behaviour or when using newer node versions (some contexts can be found [here](https://github.com/elastic/observability-robots/issues/1453) )
Having the permission issue #338 recently, and the possible fix #339 causing another issue affecting test results, I wanted to explore the github actions for running tests. I've tried to run the tests on macos(this let us bypass the setup for `Xvfb`) and It seems quite promising. Here's the impact I've found when opting in for github actions:

### Pros:
- Do not need to build the docker image and maintain it. The docker image is only used by the test step and when we bump the release step, it doesn't run the test step anyways so it won't affect anything else.
- It can cache the npm modules until `package-lock.json` changes) so it _can_ reduce the time for checks significantly
- We can easily reproduce the same behavior as it does on my local machine. previously tests didn't fail at all on CI but failed on my local machine. Running tests locally using the docker image doesn't really work well for this project, as we use a native module(sharp) and the developers use macOS, it throws as the module is not compatible and we might need force-install the native module built for linux.(yet there are some differences even though we do that as docker for Mac behaves differently to linux)


### Cons:
- Won't have CI summary comments created by Jenkins

## Next Steps
If we are happy to go forward with github actions, we need to rearrange the Jenkins file and clean-up related scripts, it will be used mainly for the release pipelines(currently release pipeline is triggered when a tag is pushed). 

## How to validate this change
push to this branch
