### PR TITLE
chore: call click stop recording to avoid tests to hang

### DIFF
--- a/e2e/tests/dragAndDrop.test.ts
+++ b/e2e/tests/dragAndDrop.test.ts
@@ -69,6 +69,7 @@ describe('Drag and Drop', () => {
     await electronService.recordClick('text=Hello Elastic Synthetics Recorder');
 
     await (await electronWindow.$('id=insert-divider-0-1')).click();
+    await electronService.clickStopRecording();
     await (await electronWindow.$('id=step-1')).hover();
     await electronWindow.mouse.down();
     await electronWindow.mouse.move(100, 100, { steps: 5 });

--- a/e2e/tests/navigation.test.ts
+++ b/e2e/tests/navigation.test.ts
@@ -55,6 +55,7 @@ describe('Navigation', () => {
     await electronService.clickStartRecording();
     await electronService.waitForPageToBeIdle();
     await electronService.navigateRecordingBrowser(url);
+    await electronService.clickStopRecording();
 
     expect(await electronWindow.$('text=Step 1')).toBeTruthy();
     expect(await electronWindow.$(`text=navigate ${env.DEMO_APP_URL}`)).toBeTruthy();

--- a/e2e/tests/runTest.test.ts
+++ b/e2e/tests/runTest.test.ts
@@ -37,6 +37,7 @@ describe('Test Button', () => {
     await electronService.enterTestUrl(env.DEMO_APP_URL);
     await electronService.clickStartRecording();
     await electronService.waitForPageToBeIdle();
+    await electronService.clickStopRecording();
 
     const testButton = await electronWindow.$(`[aria-label="Test"]`);
     expect(testButton).toBeTruthy();


### PR DESCRIPTION
# Context

The execution of the e2e from dev machines (tested M1 **laptops**) wasn't working correctly. The tests were hanging indefinitely, and it was needed to close the electron application manually for each one to make it pass.

# Approach chose to fix this

When running each test **individually** it was detected that one of them `(actionValues.test.ts`) was **always** working.

That test is one of the few tests using the statement `await electronService.clickStopRecording(); `

It turns out that the absence of that line on the other tests was the main reason behind the problem. That's why the `await electronService.terminate();` inside the `afterEach` wasn't responding. Although not confirmed, I would dare to say that we were facing a memory issue.

I'm sharing two recordings. 


**Before the fix**


https://user-images.githubusercontent.com/15065076/210569259-fd5ebef7-db6e-404b-928f-9bcf78f104f3.mov




**After the fix** 🎉 


https://user-images.githubusercontent.com/15065076/210567959-3740b6f2-ce6d-4324-9182-536d3fc266ed.mov
