### PR TITLE
fix: close recording target browsers before terminating electron when testing

### DIFF
--- a/e2e/services/browser.ts
+++ b/e2e/services/browser.ts
@@ -96,6 +96,12 @@ export class TestBrowserService {
 
   static async closeRemoteBrowser(connectParams?: ConnectRetryParams) {
     const browser = await TestBrowserService.getRemoteBrowser(connectParams);
+    const ctxs = await browser.contexts();
+    for (const ctx of ctxs) {
+      await ctx.close();
+    }
     await browser.close();
+    // with this timeout, it will make sure the browser to be closed before terminating electron (it's an issue to mac).
+    await new Promise(r => setTimeout(r, 50));
   }
 }

--- a/e2e/services/electron.ts
+++ b/e2e/services/electron.ts
@@ -64,6 +64,7 @@ export class ElectronServiceFactory {
 
   async terminate() {
     if (!this.#instance) return;
+    await TestBrowserService.closeRemoteBrowser();
     await this.#instance.close();
     this.#instance = null;
   }


### PR DESCRIPTION
## Summary
When running e2e tests, make sure the recording target browser is closed before closing electron instance so that each test can be finished. Currently, the second instance of electron starts and hangs forever when the browser is not closed.
(It seems to be an issue only to Mac)

## Implementation details
Close all the contexts and browser before terminating electron. But the graceful termination of browser doesn't guarantee the complete close of the browser so adding setTimeout hack was needed

