### PR TITLE
chore: bump eui@72

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@elastic/datemath": "^5.0.3",
-        "@elastic/eui": "^58.1.1",
+        "@elastic/eui": "^72.1.0",
         "@elastic/synthetics": "=1.0.0-beta.38",
         "@emotion/cache": "^11.9.3",
         "@emotion/react": "^11.9.3",
@@ -2329,10 +2329,9 @@
       }
     },
     "node_modules/@elastic/eui": {
-      "version": "58.1.1",
-      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-58.1.1.tgz",
-      "integrity": "sha512-opDWwCx8Zrw6Ut9JhzfnQAqC2fYsIfhUABAMofeZHnu33WnRoPmSETrmB7nPg9ZzNKC2WTf9WfTkimyNgocGAg==",
-      "hasInstallScript": true,
+      "version": "72.1.0",
+      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-72.1.0.tgz",
+      "integrity": "sha512-H9u4ViKPqd/tc/WsE+O3gRDyoMaIbA5ccUH9xrtHzI9/1rnYdEASgVuFLZg/3gJaz1xsojaq8fEzvaPVsaAz1g==",
       "dependencies": {
         "@types/chroma-js": "^2.0.0",
         "@types/lodash": "^4.14.160",
@@ -2353,7 +2352,7 @@
         "react-beautiful-dnd": "^13.1.0",
         "react-dropzone": "^11.5.3",
         "react-element-to-jsx-string": "^14.3.4",
-        "react-focus-on": "^3.5.4",
+        "react-focus-on": "^3.7.0",
         "react-input-autosize": "^3.0.0",
         "react-is": "^17.0.2",
         "react-virtualized-auto-sizer": "^1.0.6",
@@ -2364,7 +2363,7 @@
         "rehype-stringify": "^8.0.0",
         "remark-breaks": "^2.0.2",
         "remark-emoji": "^2.1.0",
-        "remark-parse": "^8.0.3",
+        "remark-parse-no-trim": "^8.0.4",
         "remark-rehype": "^8.0.0",
         "tabbable": "^5.2.1",
         "text-diff": "^1.0.1",
@@ -2376,6 +2375,7 @@
       },
       "peerDependencies": {
         "@elastic/datemath": "^5.0.2",
+        "@emotion/css": "11.x",
         "@emotion/react": "11.x",
         "@types/react": "^16.9 || ^17.0",
         "@types/react-dom": "^16.9 || ^17.0",
@@ -2594,6 +2594,27 @@
         "@emotion/utils": "^1.2.0",
         "@emotion/weak-memoize": "^0.3.0",
         "stylis": "4.1.3"
+      }
+    },
+    "node_modules/@emotion/css": {
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.10.5.tgz",
+      "integrity": "sha512-maJy0wG82hWsiwfJpc3WrYsyVwUbdu+sdIseKUB+/OLjB8zgc3tqkT6eO0Yt0AhIkJwGGnmMY/xmQwEAgQ4JHA==",
+      "peer": true,
+      "dependencies": {
+        "@emotion/babel-plugin": "^11.10.5",
+        "@emotion/cache": "^11.10.5",
+        "@emotion/serialize": "^1.1.1",
+        "@emotion/sheet": "^1.2.1",
+        "@emotion/utils": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emotion/hash": {
@@ -5997,9 +6018,9 @@
       "dev": true
     },
     "node_modules/aria-hidden": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.1.tgz",
-      "integrity": "sha512-PN344VAf9j1EAi+jyVHOJ8XidQdPVssGco39eNcsGdM4wcsILtxrKLkbuiMfLWYROK1FjRQasMWCBttrhjnr6A==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.2.tgz",
+      "integrity": "sha512-6y/ogyDTk/7YAe91T3E2PR1ALVKyM2QbTio5HwM+N1Q6CMlCKhvClyIjkckBswa0f2xJhjsfzIGa1yVSe1UMVA==",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -11373,9 +11394,9 @@
       "dev": true
     },
     "node_modules/focus-lock": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.3.tgz",
-      "integrity": "sha512-4n0pYcPTa/uI7Q66BZna61nRT7lDhnuJ9PJr6wiDjx4uStg491ks41y7uOG+s0umaaa+hulNKSldU9aTg9/yVg==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.4.tgz",
+      "integrity": "sha512-LzZWJcOBIcHslQ46N3SUu/760iLPSrUtp8omM4gh9du438V2CQdks8TcOu1yvmu2C68nVOBnl1WFiKGPbQ8L6g==",
       "dependencies": {
         "tslib": "^2.0.3"
       },
@@ -20559,9 +20580,9 @@
       "dev": true
     },
     "node_modules/react-focus-lock": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.1.tgz",
-      "integrity": "sha512-pSWOQrUmiKLkffPO6BpMXN7SNKXMsuOakl652IBuALAu1esk+IcpJyM+ALcYzPTTFz1rD0R54aB9A4HuP5t1Wg==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.2.tgz",
+      "integrity": "sha512-5JfrsOKyA5Zn3h958mk7bAcfphr24jPoMoznJ8vaJF6fUrPQ8zrtEd3ILLOK8P5jvGxdMd96OxWNjDzATfR2qw==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "focus-lock": "^0.11.2",
@@ -20581,13 +20602,13 @@
       }
     },
     "node_modules/react-focus-on": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.6.0.tgz",
-      "integrity": "sha512-onIRjpd9trAUenXNdDcvjc8KJUSklty4X/Gr7hAm/MzM7ekSF2pg9D8KBKL7ipige22IAPxLRRf/EmJji9KD6Q==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.7.0.tgz",
+      "integrity": "sha512-TsCnbJr4qjqFatJ4U1N8qGSZH+FUzxJ5mJ5ta7TY2YnDmUbGGmcvZMTZgGjQ1fl6vlztsMyg6YyZlPAeeIhEUg==",
       "dependencies": {
-        "aria-hidden": "^1.1.3",
-        "react-focus-lock": "^2.9.0",
-        "react-remove-scroll": "^2.5.2",
+        "aria-hidden": "^1.2.2",
+        "react-focus-lock": "^2.9.2",
+        "react-remove-scroll": "^2.5.5",
         "react-style-singleton": "^2.2.0",
         "tslib": "^2.3.1",
         "use-callback-ref": "^1.3.0",
@@ -22540,10 +22561,10 @@
         "unist-util-visit": "^2.0.3"
       }
     },
-    "node_modules/remark-parse": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.3.tgz",
-      "integrity": "sha512-E1K9+QLGgggHxCQtLt++uXltxEprmWzNfg+MxpfHsZlrddKzZ/hZyWHDbK3/Ap8HJQqYJRXP+jHczdL6q6i85Q==",
+    "node_modules/remark-parse-no-trim": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/remark-parse-no-trim/-/remark-parse-no-trim-8.0.4.tgz",
+      "integrity": "sha512-WtqeHNTZ0LSdyemmY1/G6y9WoEFblTtgckfKF5/NUnri919/0/dEu8RCDfvXtJvu96soMvT+mLWWgYVUaiHoag==",
       "dependencies": {
         "ccount": "^1.0.0",
         "collapse-white-space": "^1.0.2",
@@ -22555,7 +22576,6 @@
         "parse-entities": "^2.0.0",
         "repeat-string": "^1.5.4",
         "state-toggle": "^1.0.0",
-        "trim": "0.0.1",
         "trim-trailing-lines": "^1.0.0",
         "unherit": "^1.0.4",
         "unist-util-remove-position": "^2.0.0",
@@ -24791,11 +24811,6 @@
       "bin": {
         "tree-kill": "cli.js"
       }
-    },
-    "node_modules/trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ=="
     },
     "node_modules/trim-trailing-lines": {
       "version": "1.1.4",
@@ -28195,9 +28210,9 @@
       }
     },
     "@elastic/eui": {
-      "version": "58.1.1",
-      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-58.1.1.tgz",
-      "integrity": "sha512-opDWwCx8Zrw6Ut9JhzfnQAqC2fYsIfhUABAMofeZHnu33WnRoPmSETrmB7nPg9ZzNKC2WTf9WfTkimyNgocGAg==",
+      "version": "72.1.0",
+      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-72.1.0.tgz",
+      "integrity": "sha512-H9u4ViKPqd/tc/WsE+O3gRDyoMaIbA5ccUH9xrtHzI9/1rnYdEASgVuFLZg/3gJaz1xsojaq8fEzvaPVsaAz1g==",
       "requires": {
         "@types/chroma-js": "^2.0.0",
         "@types/lodash": "^4.14.160",
@@ -28218,7 +28233,7 @@
         "react-beautiful-dnd": "^13.1.0",
         "react-dropzone": "^11.5.3",
         "react-element-to-jsx-string": "^14.3.4",
-        "react-focus-on": "^3.5.4",
+        "react-focus-on": "^3.7.0",
         "react-input-autosize": "^3.0.0",
         "react-is": "^17.0.2",
         "react-virtualized-auto-sizer": "^1.0.6",
@@ -28229,7 +28244,7 @@
         "rehype-stringify": "^8.0.0",
         "remark-breaks": "^2.0.2",
         "remark-emoji": "^2.1.0",
-        "remark-parse": "^8.0.3",
+        "remark-parse-no-trim": "^8.0.4",
         "remark-rehype": "^8.0.0",
         "tabbable": "^5.2.1",
         "text-diff": "^1.0.1",
@@ -28412,6 +28427,19 @@
         "@emotion/utils": "^1.2.0",
         "@emotion/weak-memoize": "^0.3.0",
         "stylis": "4.1.3"
+      }
+    },
+    "@emotion/css": {
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.10.5.tgz",
+      "integrity": "sha512-maJy0wG82hWsiwfJpc3WrYsyVwUbdu+sdIseKUB+/OLjB8zgc3tqkT6eO0Yt0AhIkJwGGnmMY/xmQwEAgQ4JHA==",
+      "peer": true,
+      "requires": {
+        "@emotion/babel-plugin": "^11.10.5",
+        "@emotion/cache": "^11.10.5",
+        "@emotion/serialize": "^1.1.1",
+        "@emotion/sheet": "^1.2.1",
+        "@emotion/utils": "^1.2.0"
       }
     },
     "@emotion/hash": {
@@ -31083,9 +31111,9 @@
       "dev": true
     },
     "aria-hidden": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.1.tgz",
-      "integrity": "sha512-PN344VAf9j1EAi+jyVHOJ8XidQdPVssGco39eNcsGdM4wcsILtxrKLkbuiMfLWYROK1FjRQasMWCBttrhjnr6A==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.2.tgz",
+      "integrity": "sha512-6y/ogyDTk/7YAe91T3E2PR1ALVKyM2QbTio5HwM+N1Q6CMlCKhvClyIjkckBswa0f2xJhjsfzIGa1yVSe1UMVA==",
       "requires": {
         "tslib": "^2.0.0"
       },
@@ -35047,9 +35075,9 @@
       "dev": true
     },
     "focus-lock": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.3.tgz",
-      "integrity": "sha512-4n0pYcPTa/uI7Q66BZna61nRT7lDhnuJ9PJr6wiDjx4uStg491ks41y7uOG+s0umaaa+hulNKSldU9aTg9/yVg==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.4.tgz",
+      "integrity": "sha512-LzZWJcOBIcHslQ46N3SUu/760iLPSrUtp8omM4gh9du438V2CQdks8TcOu1yvmu2C68nVOBnl1WFiKGPbQ8L6g==",
       "requires": {
         "tslib": "^2.0.3"
       },
@@ -41633,9 +41661,9 @@
       "dev": true
     },
     "react-focus-lock": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.1.tgz",
-      "integrity": "sha512-pSWOQrUmiKLkffPO6BpMXN7SNKXMsuOakl652IBuALAu1esk+IcpJyM+ALcYzPTTFz1rD0R54aB9A4HuP5t1Wg==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.2.tgz",
+      "integrity": "sha512-5JfrsOKyA5Zn3h958mk7bAcfphr24jPoMoznJ8vaJF6fUrPQ8zrtEd3ILLOK8P5jvGxdMd96OxWNjDzATfR2qw==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "focus-lock": "^0.11.2",
@@ -41646,13 +41674,13 @@
       }
     },
     "react-focus-on": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.6.0.tgz",
-      "integrity": "sha512-onIRjpd9trAUenXNdDcvjc8KJUSklty4X/Gr7hAm/MzM7ekSF2pg9D8KBKL7ipige22IAPxLRRf/EmJji9KD6Q==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.7.0.tgz",
+      "integrity": "sha512-TsCnbJr4qjqFatJ4U1N8qGSZH+FUzxJ5mJ5ta7TY2YnDmUbGGmcvZMTZgGjQ1fl6vlztsMyg6YyZlPAeeIhEUg==",
       "requires": {
-        "aria-hidden": "^1.1.3",
-        "react-focus-lock": "^2.9.0",
-        "react-remove-scroll": "^2.5.2",
+        "aria-hidden": "^1.2.2",
+        "react-focus-lock": "^2.9.2",
+        "react-remove-scroll": "^2.5.5",
         "react-style-singleton": "^2.2.0",
         "tslib": "^2.3.1",
         "use-callback-ref": "^1.3.0",
@@ -43152,10 +43180,10 @@
         "unist-util-visit": "^2.0.3"
       }
     },
-    "remark-parse": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.3.tgz",
-      "integrity": "sha512-E1K9+QLGgggHxCQtLt++uXltxEprmWzNfg+MxpfHsZlrddKzZ/hZyWHDbK3/Ap8HJQqYJRXP+jHczdL6q6i85Q==",
+    "remark-parse-no-trim": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/remark-parse-no-trim/-/remark-parse-no-trim-8.0.4.tgz",
+      "integrity": "sha512-WtqeHNTZ0LSdyemmY1/G6y9WoEFblTtgckfKF5/NUnri919/0/dEu8RCDfvXtJvu96soMvT+mLWWgYVUaiHoag==",
       "requires": {
         "ccount": "^1.0.0",
         "collapse-white-space": "^1.0.2",
@@ -43167,7 +43195,6 @@
         "parse-entities": "^2.0.0",
         "repeat-string": "^1.5.4",
         "state-toggle": "^1.0.0",
-        "trim": "0.0.1",
         "trim-trailing-lines": "^1.0.0",
         "unherit": "^1.0.4",
         "unist-util-remove-position": "^2.0.0",
@@ -44872,11 +44899,6 @@
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
-    },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ=="
     },
     "trim-trailing-lines": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
-    "@elastic/eui": "^58.1.1",
+    "@elastic/eui": "^72.1.0",
     "@elastic/synthetics": "=1.0.0-beta.38",
     "@emotion/cache": "^11.9.3",
     "@emotion/react": "^11.9.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,7 @@ const cache = createCache({
   key: 'elastic-synthetics-recorder',
   container: document.querySelector<HTMLElement>('meta[name="global-style-insert"]') ?? undefined,
 });
+cache.compat = true;
 
 export default function App() {
   const [url, setUrl] = useState('');

--- a/src/components/ActionDetail/ActionDetail.test.tsx
+++ b/src/components/ActionDetail/ActionDetail.test.tsx
@@ -41,7 +41,7 @@ describe('<ActionDetail />', () => {
     jest.restoreAllMocks();
   });
 
-  describe('navigate', () => {
+  describe.only('navigate', () => {
     const url = 'https://example.com';
     let navigateAction: ActionContext;
     beforeEach(() => {

--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -39,12 +39,12 @@ const Header = styled(EuiFlexGroup)`
   background-color: ${props => props.theme.colors.emptyShade};
   border-bottom: ${props => props.theme.border.thin};
   margin: 0px;
-  padding: 8px;
+  padding: 14px;
 `;
 
 const TestButtonDivider = styled(EuiFlexItem)`
   border-right: ${props => props.theme.border.thin};
-  padding-right: 16px;
+  padding-right: 12px;
 `;
 
 interface IHeaderControls {

--- a/src/components/Header/Title.tsx
+++ b/src/components/Header/Title.tsx
@@ -43,10 +43,10 @@ export function Title() {
     <EuiPageHeader
       style={{
         backgroundColor: euiTheme.colors.emptyShade,
-        padding: 4,
         boxShadow: `0px 2px ${euiTheme.colors.lightestShade}`,
       }}
-      bottomBorder
+      paddingSize="s"
+      bottomBorder="extended"
     >
       <EuiFlexGroup alignItems="center" gutterSize="s" justifyContent="spaceBetween">
         <EuiFlexItem grow={false}>
@@ -63,7 +63,7 @@ export function Title() {
           </h1>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiBetaBadge label="BETA" />
+          <EuiBetaBadge label="BETA" alignment="middle" />
         </EuiFlexItem>
         <EuiFlexItem />
         <EuiFlexItem grow={false}>


### PR DESCRIPTION
Bump elastic@eui to latest version with some UI adjustment for the changed parts due to the update.

TODO:
- [ ]  mute console.error that mentioned in https://github.com/elastic/eui/pull/5920
<img width="979" alt="image" src="https://user-images.githubusercontent.com/16660866/211464442-3f62ce7e-0f50-40e7-941f-1b08184edbb9.png">
