### PR TITLE
Add helper defaults for `IToastContext`

### DIFF
--- a/src/helpers/test/defaults.ts
+++ b/src/helpers/test/defaults.ts
@@ -26,6 +26,7 @@ import { RecordingStatus } from '../../common/types';
 import { ICommunicationContext } from '../../contexts/CommunicationContext';
 import { IRecordingContext } from '../../contexts/RecordingContext';
 import { IStepsContext } from '../../contexts/StepsContext';
+import { IToastContext } from '../../contexts/ToastContext';
 import { IUrlContext } from '../../contexts/UrlContext';
 
 export const getRecordingContextDefaults = (): IRecordingContext => ({
@@ -57,6 +58,14 @@ export const getStepsContextDefaults = (): IStepsContext => ({
   onSplitStep: jest.fn(),
   onStepDetailChange: jest.fn(),
   onUpdateAction: jest.fn(),
+});
+
+export const getToastContextDefaults = (): IToastContext => ({
+  sendToast: jest.fn(),
+  dismissToast: jest.fn(),
+  toasts: [],
+  toastLifeTimeMs: 5000,
+  setToastLifeTimeMs: jest.fn(),
 });
 
 export const getCommunicationContextDefaults = (): ICommunicationContext => ({

--- a/src/helpers/test/render.tsx
+++ b/src/helpers/test/render.tsx
@@ -28,12 +28,14 @@ import { CommunicationContext, ICommunicationContext } from '../../contexts/Comm
 import { IRecordingContext, RecordingContext } from '../../contexts/RecordingContext';
 import { IStepsContext, StepsContext } from '../../contexts/StepsContext';
 import { StyledComponentsEuiProvider } from '../../contexts/StyledComponentsEuiProvider';
+import { IToastContext, ToastContext } from '../../contexts/ToastContext';
 import { IUrlContext, UrlContext } from '../../contexts/UrlContext';
 import {
   getRecordingContextDefaults,
   getUrlContextDefaults,
   getStepsContextDefaults,
   getCommunicationContextDefaults,
+  getToastContextDefaults,
 } from './defaults';
 import { RenderContexts } from './RenderContexts';
 
@@ -46,6 +48,7 @@ export function render<ComponentType>(
       recording?: Partial<IRecordingContext>;
       steps?: Partial<IStepsContext>;
       url?: Partial<IUrlContext>;
+      toast?: Partial<IToastContext>;
     };
   }
 ): RenderResult {
@@ -69,6 +72,11 @@ export function render<ComponentType>(
       defaults: getCommunicationContextDefaults(),
       Context: CommunicationContext,
       overrides: options?.contextOverrides?.communication,
+    },
+    {
+      defaults: getToastContextDefaults(),
+      Context: ToastContext,
+      overrides: options?.contextOverrides?.toast,
     },
   ];
 


### PR DESCRIPTION
## Summary

This is a preamble to https://github.com/elastic/synthetics-recorder/issues/264 as we are missing context helper defaults for the toast context. This will enable us to mock that context when testing components that dispatch notifications to the user.

## Implementation details

Adds some defaults and supports overrides for testing components that call `ToastContext`.

## How to validate this change

There are no user-facing changes, if CI is passing this should be ok to merge. I have another patch lined up after this one that adds tests that make use of these defaults, so if there are any further issues they'll be resolved as part of that patch.