### PR TITLE
Add unit tests for `<TestResult />`

### DIFF
--- a/src/components/TestResult/TestResult.test.tsx
+++ b/src/components/TestResult/TestResult.test.tsx
@@ -1,0 +1,208 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import { fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { createStep } from '../../../common/helper/test/createAction';
+import { render } from '../../helpers/test';
+import { TestResult } from './TestResult';
+
+describe('<TestResult />', () => {
+  it('does not render the flyout if there is no result data', () => {
+    const { queryByTestId } = render(<TestResult />, {
+      contextOverrides: {
+        test: {
+          result: {
+            failed: 0,
+            succeeded: 0,
+            skipped: 0,
+            journey: {
+              status: 'succeeded',
+              steps: [],
+              type: 'project',
+            },
+          },
+        },
+      },
+    });
+    expect(queryByTestId('result-flyout-title')).toBeNull();
+  });
+
+  it('does not render the flyout if result is falsy', () => {
+    const { queryByTestId } = render(<TestResult />, {
+      contextOverrides: {
+        test: {
+          isResultFlyoutVisible: true,
+          result: undefined,
+        },
+      },
+    });
+    expect(queryByTestId('result-flyout-title')).toBeNull();
+  });
+
+  it('does not render the flyout if the total is 0', () => {
+    const { queryByTestId } = render(<TestResult />, {
+      contextOverrides: {
+        test: {
+          isResultFlyoutVisible: true,
+          result: {
+            failed: 0,
+            succeeded: 0,
+            skipped: 0,
+            journey: {
+              status: 'succeeded',
+              steps: [],
+              type: 'project',
+            },
+          },
+        },
+      },
+    });
+    expect(queryByTestId('result-flyout-title')).toBeNull();
+  });
+
+  it('renders the flyout for a success result', () => {
+    const { getByText, getByRole } = render(<TestResult />, {
+      contextOverrides: {
+        test: {
+          isResultFlyoutVisible: true,
+          result: {
+            failed: 0,
+            succeeded: 2,
+            skipped: 0,
+            journey: {
+              status: 'succeeded',
+              steps: [
+                {
+                  duration: 2332,
+                  name: 'Load page',
+                  status: 'succeeded',
+                },
+                {
+                  duration: 5023,
+                  name: 'Click save',
+                  status: 'succeeded',
+                },
+              ],
+              type: 'project',
+            },
+          },
+        },
+      },
+    });
+    expect(getByRole('heading', { name: 'Journey Test Result' }));
+    expect(getByText('1: Load page'));
+    expect(getByText('2s'));
+    expect(getByText('2: Click save'));
+    expect(getByText('5s'));
+  });
+
+  it('calls the close function on flyout close', async () => {
+    const setIsResultFlyoutVisible = jest.fn();
+    const { getByLabelText } = render(<TestResult />, {
+      contextOverrides: {
+        test: {
+          isResultFlyoutVisible: true,
+          setIsResultFlyoutVisible,
+          result: {
+            failed: 0,
+            succeeded: 2,
+            skipped: 0,
+            journey: {
+              status: 'succeeded',
+              steps: [
+                {
+                  duration: 2332,
+                  name: 'Load page',
+                  status: 'succeeded',
+                },
+                {
+                  duration: 5023,
+                  name: 'Click save',
+                  status: 'succeeded',
+                },
+              ],
+              type: 'project',
+            },
+          },
+        },
+      },
+    });
+
+    const closeButton = getByLabelText('Close this dialog');
+
+    fireEvent.click(closeButton);
+
+    await waitFor(() => {
+      expect(setIsResultFlyoutVisible).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('renders the flyout with error message and code for failed step', async () => {
+    const errorMessage = 'Save button timeout expired';
+    const callMain = jest.fn();
+    callMain.mockImplementation((arg: string, obj: any) => {
+      return `
+step('Click save', () => {
+	await page.click('my button');
+})`;
+    });
+    const { getByText, queryByText } = render(<TestResult />, {
+      contextOverrides: {
+        // @ts-expect-error partial implementation for testing
+        communication: { ipc: { callMain } },
+        steps: { steps: [createStep(['Click save'])] },
+        test: {
+          isResultFlyoutVisible: true,
+          result: {
+            failed: 1,
+            succeeded: 1,
+            skipped: 0,
+            journey: {
+              status: 'failed',
+              steps: [
+                {
+                  duration: 2332,
+                  name: 'Load page',
+                  status: 'succeeded',
+                },
+                {
+                  duration: 5023,
+                  name: 'Click save',
+                  status: 'failed',
+                  error: Error(errorMessage),
+                },
+              ],
+              type: 'project',
+            },
+          },
+        },
+      },
+    });
+    expect(getByText(errorMessage));
+    await waitFor(() => {
+      queryByText(`step('Click save', () => {`, { exact: false });
+    });
+  });
+});

--- a/src/helpers/test/defaults.ts
+++ b/src/helpers/test/defaults.ts
@@ -26,6 +26,7 @@ import { RecordingStatus } from '../../common/types';
 import { ICommunicationContext } from '../../contexts/CommunicationContext';
 import { IRecordingContext } from '../../contexts/RecordingContext';
 import { IStepsContext } from '../../contexts/StepsContext';
+import { ITestContext } from '../../contexts/TestContext';
 import { IToastContext } from '../../contexts/ToastContext';
 import { IUrlContext } from '../../contexts/UrlContext';
 
@@ -58,6 +59,17 @@ export const getStepsContextDefaults = (): IStepsContext => ({
   onSplitStep: jest.fn(),
   onStepDetailChange: jest.fn(),
   onUpdateAction: jest.fn(),
+});
+
+export const getTestContextDefaults = (): ITestContext => ({
+  codeBlocks: '',
+  isResultFlyoutVisible: false,
+  isTestInProgress: false,
+  onTest: jest.fn(),
+  setCodeBlocks: jest.fn(),
+  setResult: jest.fn(),
+  setIsTestInProgress: jest.fn(),
+  setIsResultFlyoutVisible: jest.fn(),
 });
 
 export const getToastContextDefaults = (): IToastContext => ({

--- a/src/helpers/test/render.tsx
+++ b/src/helpers/test/render.tsx
@@ -28,6 +28,7 @@ import { CommunicationContext, ICommunicationContext } from '../../contexts/Comm
 import { IRecordingContext, RecordingContext } from '../../contexts/RecordingContext';
 import { IStepsContext, StepsContext } from '../../contexts/StepsContext';
 import { StyledComponentsEuiProvider } from '../../contexts/StyledComponentsEuiProvider';
+import { ITestContext, TestContext } from '../../contexts/TestContext';
 import { IToastContext, ToastContext } from '../../contexts/ToastContext';
 import { IUrlContext, UrlContext } from '../../contexts/UrlContext';
 import {
@@ -36,6 +37,7 @@ import {
   getStepsContextDefaults,
   getCommunicationContextDefaults,
   getToastContextDefaults,
+  getTestContextDefaults,
 } from './defaults';
 import { RenderContexts } from './RenderContexts';
 
@@ -48,6 +50,7 @@ export function render<ComponentType>(
       recording?: Partial<IRecordingContext>;
       steps?: Partial<IStepsContext>;
       url?: Partial<IUrlContext>;
+      test?: Partial<ITestContext>;
       toast?: Partial<IToastContext>;
     };
   }
@@ -72,6 +75,11 @@ export function render<ComponentType>(
       defaults: getCommunicationContextDefaults(),
       Context: CommunicationContext,
       overrides: options?.contextOverrides?.communication,
+    },
+    {
+      defaults: getTestContextDefaults(),
+      Context: TestContext,
+      overrides: options?.contextOverrides?.test,
     },
     {
       defaults: getToastContextDefaults(),


### PR DESCRIPTION
## Summary

**NOTE TO REVIEWERS:** This should not be reviewed until #353 is merged.

Related to #264. Adds test for `<TestResult />`.

## Implementation details

Adds unit tests.

## How to validate this change

If the test looks like it makes sense and it is passing CI no further testing needed.