### PR TITLE
Add unit tests for `useGlobalToasts`

### DIFF
--- a/src/hooks/useGlobalToasts.test.ts
+++ b/src/hooks/useGlobalToasts.test.ts
@@ -22,8 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import { act } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import { useGlobalToasts } from './useGlobalToasts';
 
 describe('useGlobalToasts', () => {

--- a/src/hooks/useGlobalToasts.test.ts
+++ b/src/hooks/useGlobalToasts.test.ts
@@ -1,0 +1,57 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import { act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { useGlobalToasts } from './useGlobalToasts';
+
+describe('useGlobalToasts', () => {
+  it('should add a toast', () => {
+    const { result } = renderHook(() => useGlobalToasts());
+    act(() => {
+      result.current.sendToast({ id: '1', title: 'Test Toast' });
+    });
+    expect(result.current.toasts).toEqual([{ id: '1', title: 'Test Toast' }]);
+  });
+
+  it('should dismiss a toast', () => {
+    const { result } = renderHook(() => useGlobalToasts());
+    act(() => {
+      result.current.sendToast({ id: '1', title: 'Test Toast' });
+    });
+    expect(result.current.toasts).toEqual([{ id: '1', title: 'Test Toast' }]);
+    act(() => {
+      result.current.dismissToast({ id: '1', title: 'Test Toast' });
+    });
+    expect(result.current.toasts).toEqual([]);
+  });
+
+  it('should set toastLifeTimeMs', () => {
+    const { result } = renderHook(() => useGlobalToasts());
+    act(() => {
+      result.current.setToastLifeTimeMs(10000);
+    });
+    expect(result.current.toastLifeTimeMs).toEqual(10000);
+  });
+});

--- a/src/hooks/useGlobalToasts.ts
+++ b/src/hooks/useGlobalToasts.ts
@@ -32,7 +32,7 @@ export function useGlobalToasts(): IToastContext {
 
   const dismissToast = useCallback(
     (toast: Toast) => {
-      setToasts(toasts => toasts.filter(t => t !== toast));
+      setToasts(toasts => toasts.filter(({ id }) => id !== toast.id));
     },
     [setToasts]
   );


### PR DESCRIPTION
## Summary

**NOTE TO REVIEWERS:** This should not be reviewed until #353 is merged.

Related to #264. Adds test for `useGlobalToasts`.

## Implementation details

Adds unit tests.

## How to validate this change

If the test looks like it makes sense and it is passing CI no further testing needed.