### PR TITLE
chore: enable chromium sandboxing

### DIFF
--- a/electron/execution.ts
+++ b/electron/execution.ts
@@ -58,6 +58,7 @@ async function launchContext() {
   const browser = await chromium.launch({
     headless: IS_TEST_ENV,
     executablePath: EXECUTABLE_PATH,
+    chromiumSandbox: true,
     args: IS_TEST_ENV ? [`--remote-debugging-port=${CDP_TEST_PORT}`] : [],
   });
 
@@ -276,7 +277,13 @@ function onTest(mainWindowEmitter: EventEmitter) {
 
     try {
       const isProject = data.isProject;
-      const args = ['--no-headless', '--reporter=json', '--screenshots=off', '--no-throttling'];
+      const args = [
+        '--no-headless',
+        '--reporter=json',
+        '--screenshots=off',
+        '--no-throttling',
+        '--sandbox',
+      ];
       const filePath = join(JOURNEY_DIR, 'recorded.journey.js');
       if (!isProject) {
         args.push('--inline');


### PR DESCRIPTION
closes #277 

## Summary
Enable chromium sandboxing for the recording target browser and synthetics

## Implementation details
Pass flags enabling sandboxing

## How to validate this change
Run the [builds](https://github.com/elastic/synthetics-recorder/releases/tag/untagged-ae6f46a04338bfd80de4) of this branch on all supported OS:
- [x] MacOS - ARM
- [x] MacOS - Intel
- [x] Linux
- [x] Windows
