### PR TITLE
Add more unit tests for `useDrop`

### DIFF
--- a/src/helpers/test/defaults.ts
+++ b/src/helpers/test/defaults.ts
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 import { RecordingStatus } from '../../common/types';
 import { ICommunicationContext } from '../../contexts/CommunicationContext';
+import { IDragAndDropContext } from '../../contexts/DragAndDropContext';
 import { IRecordingContext } from '../../contexts/RecordingContext';
 import { IStepsContext } from '../../contexts/StepsContext';
 import { ITestContext } from '../../contexts/TestContext';
@@ -87,4 +88,9 @@ export const getCommunicationContextDefaults = (): ICommunicationContext => ({
     callMain: jest.fn(),
     removeListener: jest.fn(),
   },
+});
+
+export const getDragAndDropContextDefaults = (): IDragAndDropContext => ({
+  dragIndex: undefined,
+  setDragIndex: jest.fn(),
 });

--- a/src/helpers/test/render.tsx
+++ b/src/helpers/test/render.tsx
@@ -25,6 +25,7 @@ THE SOFTWARE.
 import { render as rtlRender, RenderResult, RenderOptions } from '@testing-library/react';
 import React from 'react';
 import { CommunicationContext, ICommunicationContext } from '../../contexts/CommunicationContext';
+import { DragAndDropContext, IDragAndDropContext } from '../../contexts/DragAndDropContext';
 import { IRecordingContext, RecordingContext } from '../../contexts/RecordingContext';
 import { IStepsContext, StepsContext } from '../../contexts/StepsContext';
 import { StyledComponentsEuiProvider } from '../../contexts/StyledComponentsEuiProvider';
@@ -38,6 +39,7 @@ import {
   getCommunicationContextDefaults,
   getToastContextDefaults,
   getTestContextDefaults,
+  getDragAndDropContextDefaults,
 } from './defaults';
 import { RenderContexts } from './RenderContexts';
 
@@ -50,6 +52,7 @@ export function TestContextWrapper<ComponentType>({
     | React.ReactElement<ComponentType, string | React.JSXElementConstructor<any>>;
   contextOverrides?: {
     communication?: Partial<ICommunicationContext>;
+    dragAndDrop?: Partial<IDragAndDropContext>;
     recording?: Partial<IRecordingContext>;
     steps?: Partial<IStepsContext>;
     url?: Partial<IUrlContext>;
@@ -87,6 +90,11 @@ export function TestContextWrapper<ComponentType>({
       defaults: getToastContextDefaults(),
       Context: ToastContext,
       overrides: contextOverrides?.toast,
+    },
+    {
+      defaults: getDragAndDropContextDefaults(),
+      Context: DragAndDropContext,
+      overrides: contextOverrides?.dragAndDrop,
     },
   ];
 

--- a/src/hooks/useDrop.ts
+++ b/src/hooks/useDrop.ts
@@ -52,10 +52,11 @@ interface DropProps {
   onDragLeave?: DragEvent;
   onDragOver?: DragEvent;
 }
+
 export function useDrop(stepIndex: number, actionIndex: number) {
   const { dragIndex } = useContext(DragAndDropContext);
   const { steps, onDropStep, onSplitStep } = useContext(StepsContext);
-  const [dropzoneOver, setDropzeonOver] = useState(false);
+  const [dropzoneOver, setDropzoneOver] = useState(false);
   const [enterTarget, setEnterTarget] = useState<EventTarget | undefined>(undefined);
 
   const splitStepAtAction = useCallback(() => {
@@ -70,20 +71,20 @@ export function useDrop(stepIndex: number, actionIndex: number) {
       const { initiatorIndex } = JSON.parse(
         e.dataTransfer.getData(DRAG_AND_DROP_DATA_TRANSFER_TYPE)
       ) as StepSeparatorDragDropDataTransfer;
-      setDropzeonOver(false);
+      setDropzoneOver(false);
       onDropStep(stepIndex, initiatorIndex, actionIndex);
       e.preventDefault();
     };
     onDropActions.onDragEnter = e => {
       setEnterTarget(e.target);
-      setDropzeonOver(true);
+      setDropzoneOver(true);
       e.preventDefault();
     };
     onDropActions.onDragOver = e => {
       e.preventDefault();
     };
     onDropActions.onDragLeave = e => {
-      if (e.target === enterTarget) setDropzeonOver(false);
+      if (e.target === enterTarget) setDropzoneOver(false);
     };
   }
 


### PR DESCRIPTION
## Summary

Related to #264. Adds test for `useDrop`.

## Implementation details

Adds unit tests.

## How to validate this change

If the test looks like it makes sense and it is passing CI no further testing needed.