### PR TITLE
feat: add acknowledgement menu item to show NOTICE.txt in app

### DIFF
--- a/electron/electron.ts
+++ b/electron/electron.ts
@@ -93,7 +93,7 @@ async function createMainWindow() {
     createMenu();
   }
 }
-
+app.setName('Elastic Synthetics Recorder');
 app.on('activate', createMainWindow);
 
 app.on('window-all-closed', () => {

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -105,7 +105,7 @@ async function showNotice() {
   const { x, y } = parent.getBounds();
   const child = new BrowserWindow({
     parent,
-    title: 'Acknowledgement',
+    title: 'Acknowledgements',
     x: x + 50,
     y: y + 50,
   });

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -23,6 +23,9 @@ THE SOFTWARE.
 */
 
 import type { MenuItemConstructorOptions } from 'electron';
+import { BrowserWindow, shell } from 'electron';
+import isDev from 'electron-is-dev';
+import path from 'path';
 
 export function buildMenu(appName: string, initMain: () => void): MenuItemConstructorOptions[] {
   return [
@@ -72,5 +75,44 @@ export function buildMenu(appName: string, initMain: () => void): MenuItemConstr
         { role: 'front' },
       ],
     },
+    {
+      role: 'help',
+      submenu: [
+        {
+          label: 'Learn More',
+          click: async () => {
+            await shell.openExternal(
+              'https://www.elastic.co/guide/en/observability/current/synthetics-recorder.html'
+            );
+          },
+        },
+        {
+          label: 'Acknowledgement',
+          click: async () => {
+            await showNotice();
+          },
+        },
+      ],
+    },
   ];
+}
+
+async function showNotice() {
+  const parent = BrowserWindow.getFocusedWindow();
+  if (parent == null) {
+    return;
+  }
+  const { x, y } = parent.getBounds();
+  const child = new BrowserWindow({
+    parent,
+    title: 'Acknowledgement',
+    x: x + 50,
+    y: y + 50,
+  });
+  const resourceDir = isDev ? path.join(__dirname, '../../') : process.resourcesPath;
+  const pathToNotice = path.join(resourceDir, 'NOTICE.txt');
+  child.loadFile(pathToNotice);
+  child.once('ready-to-show', () => {
+    child.show();
+  });
 }

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -23,9 +23,9 @@ THE SOFTWARE.
 */
 
 import type { MenuItemConstructorOptions } from 'electron';
+import path from 'path';
 import { BrowserWindow, shell } from 'electron';
 import isDev from 'electron-is-dev';
-import path from 'path';
 
 export function buildMenu(appName: string, initMain: () => void): MenuItemConstructorOptions[] {
   return [
@@ -87,7 +87,7 @@ export function buildMenu(appName: string, initMain: () => void): MenuItemConstr
           },
         },
         {
-          label: 'Acknowledgement',
+          label: 'Acknowledgements',
           click: async () => {
             await showNotice();
           },
@@ -109,6 +109,7 @@ async function showNotice() {
     x: x + 50,
     y: y + 50,
   });
+  child.menuBarVisible = false;
   const resourceDir = isDev ? path.join(__dirname, '../../') : process.resourcesPath;
   const pathToNotice = path.join(resourceDir, 'NOTICE.txt');
   child.loadFile(pathToNotice);

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -25,7 +25,7 @@ const { notarize } = require('@electron/notarize');
 
 exports.default = async function notarizing(context) {
   const { electronPlatformName, appOutDir } = context;
-  if (electronPlatformName !== 'darwin') {
+  if (electronPlatformName !== 'darwin' || process.env.SKIP_NOTARIZATION) {
     return;
   }
   const appName = context.packager.appInfo.productFilename;


### PR DESCRIPTION
closes #265 

## Summary
Users can check license & thirdparty notices within the app from the Help > Acknowledgement menu item.
<!-- What does this change do? Which issue does it solve? -->

[![Image from Gyazo](https://i.gyazo.com/b62d3292db1abea603ee49d3589ca0a4.gif)](https://gyazo.com/b62d3292db1abea603ee49d3589ca0a4)


## Implementation details
Get NOTICE.txt and display it in a child browser window. The path to do it is to click through _Help > Acknowledgement_.

The [initial plan](https://github.com/elastic/synthetics-recorder/issues/265#issuecomment-1219654515) was to add a button in About box that opens up the child window but Electron doesn't provide API or options to customize the About panel. So I chose to add it as a menu item to `Help` menu(Also notice that I've added _Learn more_ menu that links to the documentation page.)
 

## How to validate this change
- [x] Get confirmation about the wording and the menu item location(under Help) from @drewpost and @paulb-elastic 
- [x] Run the [builds](https://github.com/elastic/synthetics-recorder/releases) of this branch on all supported OS and check the `NOTICE.txt` can be accessed properly on each platform:
  - [x] MacOS - ARM
  - [x] MacOS - Intel
  - [x] Linux
  - [x] Windows