### PR TITLE
Do not collect test coverage data on test files

### DIFF
--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -27,6 +27,7 @@ module.exports = {
     {
       displayName: 'node',
       preset: 'ts-jest',
+      coveragePathIgnorePatterns: ['.test.ts', '.test.js', '.test.tsx', '.test.jsx'],
       testEnvironment: 'node',
       testMatch: ['**/?(*.)+(spec|test).[tj]s'],
       testPathIgnorePatterns: [`node_modules`, `\\.cache`, `e2e`, `build`],
@@ -34,6 +35,7 @@ module.exports = {
     {
       displayName: 'components',
       preset: 'ts-jest',
+      coveragePathIgnorePatterns: ['.test.ts', '.test.js', '.test.tsx', '.test.jsx'],
       testEnvironment: 'jsdom',
       testMatch: ['**/?(*.)+(spec|test).[tj]sx'],
       setupFilesAfterEnv: ['./jest.unit.setup.js'],


### PR DESCRIPTION
Right now, we collect test coverage data on test files themselves.

This makes the coverage metrics in aggregate look much lower than they really are, as test files oftentimes contain more code than the files they're actually testing.

## Testing

To test this, run `npm run test:unit:watch`. After the test runs complete, open the HTML doc at the root of the `coverage` directory and ensure that you don't see test files reflected in the coverage metrics.