### PR TITLE
Add unit tests for `ExportFlyout`

### DIFF
--- a/src/components/ExportScriptFlyout/Body.test.tsx
+++ b/src/components/ExportScriptFlyout/Body.test.tsx
@@ -1,0 +1,68 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import { fireEvent } from '@testing-library/react';
+import React from 'react';
+import { render } from '../../helpers/test';
+import { Body } from './Body';
+
+describe('Body', () => {
+  it('renders a checkbox with the correct label and checked state', () => {
+    const code = 'const foo = "bar";';
+    const exportAsProject = true;
+    const setExportAsProject = jest.fn();
+    const { getByLabelText } = render(
+      <Body code={code} exportAsProject={exportAsProject} setExportAsProject={setExportAsProject} />
+    );
+
+    expect(getByLabelText('Export as project'));
+  });
+
+  it('calls the setExportAsProject prop when the checkbox is clicked', () => {
+    const code = 'const foo = "bar";';
+    const exportAsProject = true;
+    const setExportAsProject = jest.fn();
+    const { getByLabelText } = render(
+      <Body code={code} exportAsProject={exportAsProject} setExportAsProject={setExportAsProject} />
+    );
+
+    const checkbox = getByLabelText('Export as project');
+    fireEvent.click(checkbox);
+    expect(setExportAsProject).toHaveBeenCalledWith(false);
+  });
+
+  it('renders a code block with the correct code', () => {
+    const code = 'const foo = "bar";';
+    const exportAsProject = true;
+    const setExportAsProject = jest.fn();
+    const { getByLabelText } = render(
+      <Body code={code} exportAsProject={exportAsProject} setExportAsProject={setExportAsProject} />
+    );
+
+    const codeBlock = getByLabelText('Code to export');
+    const content = Array.from(codeBlock.childNodes.entries()).map(e => e[1].textContent);
+    expect(content).toHaveLength(1);
+    expect(content[0]).toEqual(code);
+  });
+});

--- a/src/components/ExportScriptFlyout/Body.tsx
+++ b/src/components/ExportScriptFlyout/Body.tsx
@@ -43,6 +43,7 @@ export function Body({ code, exportAsProject, setExportAsProject }: Props) {
       />
       <EuiSpacer />
       <EuiCodeBlock
+        aria-label="Code to export"
         id="export-code-block"
         isCopyable
         language="js"

--- a/src/components/ExportScriptFlyout/Flyout.test.tsx
+++ b/src/components/ExportScriptFlyout/Flyout.test.tsx
@@ -1,0 +1,91 @@
+/*
+MIT License
+
+Copyright (c) 2021-present, Elastic NV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import { ExportScriptFlyout } from './Flyout';
+import { render } from '../../helpers/test';
+import { getMockIpc } from '../../helpers/test/ipc';
+import { createSteps } from '../../../common/helper/test/createAction';
+
+jest.mock('../../common/shared', () => ({
+  getCodeFromActions: jest.fn().mockResolvedValue('test code'),
+}));
+
+const steps = createSteps([['step 1', 'step 2']]);
+
+describe('ExportScriptFlyout', () => {
+  it('renders header with correct text', () => {
+    const setVisible = jest.fn();
+    const { getByText } = render(<ExportScriptFlyout setVisible={setVisible} steps={steps} />, {
+      contextOverrides: {
+        communication: {
+          ipc: getMockIpc(),
+        },
+      },
+    });
+    expect(getByText('Journey code'));
+  });
+
+  it('renders code in the body', async () => {
+    const setVisible = jest.fn();
+    const { findByText } = render(<ExportScriptFlyout setVisible={setVisible} steps={steps} />, {
+      contextOverrides: {
+        communication: {
+          ipc: getMockIpc(),
+        },
+      },
+    });
+    expect(await findByText('test code'));
+  });
+
+  it('closes flyout on close button click', () => {
+    const setVisible = jest.fn();
+    const { getByText } = render(<ExportScriptFlyout setVisible={setVisible} steps={steps} />, {
+      contextOverrides: {
+        communication: {
+          ipc: getMockIpc(),
+        },
+      },
+    });
+    fireEvent.click(getByText('Close'));
+    expect(setVisible).toHaveBeenCalledWith(false);
+  });
+
+  it('toggles export as project', () => {
+    const setVisible = jest.fn();
+    const { getByLabelText } = render(
+      <ExportScriptFlyout setVisible={setVisible} steps={steps} />,
+      {
+        contextOverrides: {
+          communication: {
+            ipc: getMockIpc(),
+          },
+        },
+      }
+    );
+    fireEvent.click(getByLabelText('save-code'));
+    expect(getByLabelText('save-code'));
+  });
+});


### PR DESCRIPTION
## Summary

Related to #264. Adds test for `ExportFlyout`.

## Implementation details

Adds unit tests.

## How to validate this change

If the test looks like it makes sense and it is passing CI no further testing needed.