### PR TITLE
chore: remove new window from menu but keep the hotkey

### DIFF
--- a/electron/electron.ts
+++ b/electron/electron.ts
@@ -23,7 +23,7 @@ THE SOFTWARE.
 */
 
 import path from 'path';
-import { app, BrowserWindow, Menu } from 'electron';
+import { app, BrowserWindow, globalShortcut, Menu, webContents } from 'electron';
 import isDev from 'electron-is-dev';
 import unhandled from 'electron-unhandled';
 import debug from 'electron-debug';
@@ -41,6 +41,7 @@ const BUILD_DIR = path.join(__dirname, '..', '..', 'build');
 // so we must access the process env directly
 const IS_TEST = process.env.NODE_ENV === 'test';
 const TEST_PORT = process.env.TEST_PORT;
+const isMac = process.platform === 'darwin';
 
 async function createWindow() {
   const mainWindowEmitter = new EventEmitter();
@@ -78,7 +79,7 @@ async function initMainWindow() {
 }
 
 function createMenu() {
-  const menuTemplate = buildMenu(app.name, initMainWindow);
+  const menuTemplate = buildMenu(app.name);
   Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));
 }
 
@@ -91,10 +92,10 @@ async function createMainWindow() {
   }
 }
 app.setName('Elastic Synthetics Recorder');
-app.on('activate', createMainWindow);
+app.on('activate', createWindow);
 
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
+  if (!isMac) {
     app.quit();
   }
 });
@@ -102,5 +103,10 @@ app.on('window-all-closed', () => {
 // kick off the main process when electron is ready
 (async function () {
   await app.whenReady();
-  return createMainWindow();
+  createMainWindow();
+  if (isMac) {
+    globalShortcut.register('CommandOrControl+N', async () => {
+      await createWindow();
+    });
+  }
 })();

--- a/electron/electron.ts
+++ b/electron/electron.ts
@@ -23,7 +23,7 @@ THE SOFTWARE.
 */
 
 import path from 'path';
-import { app, BrowserWindow, globalShortcut, Menu, webContents } from 'electron';
+import { app, BrowserWindow, globalShortcut, Menu } from 'electron';
 import isDev from 'electron-is-dev';
 import unhandled from 'electron-unhandled';
 import debug from 'electron-debug';
@@ -92,7 +92,7 @@ async function createMainWindow() {
   }
 }
 app.setName('Elastic Synthetics Recorder');
-app.on('activate', createWindow);
+app.on('activate', createMainWindow);
 
 app.on('window-all-closed', () => {
   if (!isMac) {
@@ -106,7 +106,7 @@ app.on('window-all-closed', () => {
   createMainWindow();
   if (isMac) {
     globalShortcut.register('CommandOrControl+N', async () => {
-      await createWindow();
+      await initMainWindow();
     });
   }
 })();

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -27,21 +27,12 @@ import path from 'path';
 import { BrowserWindow, shell } from 'electron';
 import isDev from 'electron-is-dev';
 
-export function buildMenu(appName: string, initMain: () => void): MenuItemConstructorOptions[] {
-  return [
+export function buildMenu(appName: string): MenuItemConstructorOptions[] {
+  const isMac = process.platform === 'darwin';
+  const template: MenuItemConstructorOptions[] = [
     {
-      label: appName,
-      submenu: [
-        { role: 'about' },
-        { type: 'separator' },
-        { role: 'services', submenu: [] },
-        { type: 'separator' },
-        { role: 'hide' },
-        { role: 'hideOthers' },
-        { role: 'unhide' },
-        { type: 'separator' },
-        { role: 'quit' },
-      ],
+      label: 'File',
+      submenu: [isMac ? { role: 'close' } : { role: 'quit' }],
     },
     {
       label: 'Edit',
@@ -62,18 +53,8 @@ export function buildMenu(appName: string, initMain: () => void): MenuItemConstr
     },
     {
       role: 'window',
-      submenu: [
-        {
-          label: 'New Main Window',
-          accelerator: 'CommandOrControl+N',
-          click: initMain,
-        },
-        { role: 'close' },
-        { role: 'minimize' },
-        { role: 'zoom' },
-        { type: 'separator' },
-        { role: 'front' },
-      ],
+      label: 'Window',
+      submenu: [{ role: 'minimize' }, { role: 'zoom' }, { type: 'separator' }, { role: 'front' }],
     },
     {
       role: 'help',
@@ -95,6 +76,26 @@ export function buildMenu(appName: string, initMain: () => void): MenuItemConstr
       ],
     },
   ];
+
+  if (isMac) {
+    template.unshift({
+      role: 'appMenu',
+      label: appName,
+      submenu: [
+        { role: 'about' },
+        { type: 'separator' },
+        { role: 'services', submenu: [] },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideOthers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' },
+      ],
+    });
+  }
+
+  return template;
 }
 
 async function showNotice() {


### PR DESCRIPTION
closes #363 

## Summary
Review menu items 

## Implementation details
- Shows relevant menu per platform(example: show app menu only for MacOS)
- Removes [confusing](https://github.com/elastic/synthetics-recorder/issues/14#issuecomment-1410188463) `New Main Window` from menu (but keep the shortcut) 

## How to validate this change
Run the build on each platform and check the menus:
- MacOS:
  - [x] Elastic Synthetics Recorder menu(app menu) is shown in MacOS, not on others
  - [x] File menu is shown and contains `Close window`
  - [x] `New Main Window` menu is hidden, but the CMD+N should open the new window

- Windows
  - [x] Elastic Synthetics Recorder menu(app menu) is hidden
  - [x] File menu is shown and contains `Close window` menu item to align with other apps. (it should be extended later on)
  - [x] `New Main Window` menu item is hidden

- Linux
  - [x] Elastic Synthetics Recorder menu(app menu) is hidden
  - [x] File menu is shown and contains `Close window` menu item to align with other apps. (it should be extended later on)
  - [x] `New Main Window` menu item is hidden
<!-- How can others validate that what you've done is correct? -->

<!-- Is there any particular subject on which you need more input? -->
