### PR TITLE
chore: remove beta badge :tada:

### DIFF
--- a/src/components/Header/Title.tsx
+++ b/src/components/Header/Title.tsx
@@ -23,7 +23,6 @@ THE SOFTWARE.
 */
 
 import {
-  EuiBetaBadge,
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
@@ -63,9 +62,6 @@ export function Title() {
           >
             Elastic Synthetics Recorder
           </h1>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiBetaBadge alignment="middle" label="BETA" />
         </EuiFlexItem>
         <EuiFlexItem />
         <EuiFlexItem grow={false}>


### PR DESCRIPTION
## Summary

closes [#182](https://github.com/elastic/synthetics-dev/issues/182)
Remove `Beta` batch from the header 🎉 

## How to validate this change
Confirm that `Beta` badge is not visible when launching the app
<img width="1212" alt="image" src="https://user-images.githubusercontent.com/16660866/228746944-1eedb802-1625-4443-8a82-3a09cc9b80b4.png">

