### PR TITLE
[UI] Make page title sticky and remove box shadow

### DIFF
--- a/src/components/Header/HeaderControls.tsx
+++ b/src/components/Header/HeaderControls.tsx
@@ -38,8 +38,8 @@ import { UrlField } from './UrlField';
 const Header = styled(EuiFlexGroup)`
   background-color: ${props => props.theme.colors.emptyShade};
   border-bottom: ${props => props.theme.border.thin};
+  padding: 65px 16px 16px 16px;
   margin: 0px;
-  padding: 16px;
 `;
 
 const TestButtonDivider = styled(EuiFlexItem)`

--- a/src/components/Header/Title.tsx
+++ b/src/components/Header/Title.tsx
@@ -45,7 +45,8 @@ export function Title() {
         borderBottom: euiTheme.border.thin,
         paddingLeft: 4,
         paddingRight: 4,
-        boxShadow: `0px 2px ${euiTheme.colors.lightestShade}`,
+        position: 'fixed',
+        zIndex: 9000,
       }}
       paddingSize="xs"
     >

--- a/src/components/Header/Title.tsx
+++ b/src/components/Header/Title.tsx
@@ -46,7 +46,7 @@ export function Title() {
         paddingLeft: 4,
         paddingRight: 4,
         position: 'fixed',
-        zIndex: 9000,
+        zIndex: 999,
       }}
       paddingSize="xs"
     >


### PR DESCRIPTION
## Summary

Resolves #396 .

Makes the recorder's page header static at the top of the viewport during scrolling, and removes its box shadow.

## Implementation details

When we upgraded EUI we encountered some less-than-desired behavior (shown in the linked issue) where an expanded flyout leaves the title section of the page undimmed while the flyout is expanded. The true intention of this functionality is that the flyout will appear below a static heading UI, whereas ours fills in all the way to the top of the viewport.

To resolve this unwanted behavior, I've modified the page heading to be sticky, per the design standards shown in both the EUI docs and in multiple parts of Kibana. Now, when the user scrolls, the page heading will remain at the top of the viewport, and will remain accented when the flyout opens.

A side effect of this change is the removal of the box shadow; because it is highlighted while the flyout is open, it makes the title look weird. Rendering the shadow conditionally is also less-than-ideal because having it snap away when the flyout opens is also janky.

## How to validate this change

You can compare this change by running the recorder in dev mode and switching between this branch and main.