### PR TITLE
[Synthetics] Run lint in debug mode to list all files tested in stdout

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "release-ci": "npm run pack -- -mwl --publish=never",
     "fix-sharp": "node node_modules/sharp/install/libvips && node node_modules/sharp/install/dll-copy",
     "clean": "rm -rf ./build && rm -rf ./dist",
-    "lint": "eslint .",
+    "lint": "DEBUG=eslint:cli-engine eslint .",
     "format": "prettier --write .",
     "unused-exports": "node dev-tools/find-unused-exports.js",
     "lint:fix": "npm run lint -- --fix",


### PR DESCRIPTION
## Summary

This doesn't resolve an open issue or do anything particularly required, but it seems a DX improvement in my opinion. We can close if others disagree.

Essentially, it runs `eslint` in `DEBUG` mode, which is apparently the [prescribed](https://github.com/eslint/eslint/issues/2152#issuecomment-86975010) method of achieving this. It would be cleaner if the package supported a `--list-files`-type of flag.

## Implementation details

Runs `eslint` in debug mode to list the files linted, rather than an empty output like what it does today.

IMO this reinforces for the person running the script that everything is working ok, and it is easy to `npm run lint | grep {FILENAME}` if needed.

## How to validate this change

Run `npm run lint` and `npm run lint:fix`.