### PR TITLE
[Chore] Bump EUI and styled-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@elastic/datemath": "^5.0.3",
-        "@elastic/eui": "^77.2.0",
+        "@elastic/eui": "^78.0.0",
         "@elastic/synthetics": "=1.0.0-beta.43",
         "@emotion/cache": "^11.9.3",
         "@emotion/react": "^11.9.3",
@@ -24,7 +24,7 @@
         "playwright": "https://gitpkg.now.sh/elastic/playwright/packages/playwright-core?1.31.1-recorder",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
-        "styled-components": "^5.3.5",
+        "styled-components": "^5.3.7",
         "typescript": "^4.5.3"
       },
       "devDependencies": {
@@ -2342,9 +2342,9 @@
       }
     },
     "node_modules/@elastic/eui": {
-      "version": "77.2.0",
-      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-77.2.0.tgz",
-      "integrity": "sha512-6j3jqXdRmLGQ530GtdMrXyqi7rVd/XCMhymgO+FJiamf3dw5NF1LsXiOTn2+lTa/Tn3v2sJMVsr+SL+0h2Cd+A==",
+      "version": "78.0.0",
+      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-78.0.0.tgz",
+      "integrity": "sha512-2OZVdLHpQPm8CWpOqnBI0XisohlTtsuDub1r90UTsIZCrwevK3aBrLb8DibpggRfaXXE4QtALYpN8+JoEu8dWw==",
       "dependencies": {
         "@types/chroma-js": "^2.0.0",
         "@types/lodash": "^4.14.160",
@@ -2368,6 +2368,7 @@
         "react-focus-on": "^3.7.0",
         "react-input-autosize": "^3.0.0",
         "react-is": "^17.0.2",
+        "react-remove-scroll-bar": "^2.3.4",
         "react-virtualized-auto-sizer": "^1.0.6",
         "react-window": "^1.8.6",
         "refractor": "^3.5.0",
@@ -26351,10 +26352,9 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.6.tgz",
-      "integrity": "sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==",
-      "hasInstallScript": true,
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.10.tgz",
+      "integrity": "sha512-3kSzSBN0TiCnGJM04UwO1HklIQQSXW7rCARUk+VyMR7clz8XVlA3jijtf5ypqoDIdNMKx3la4VvaPFR855SFcg==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -30641,9 +30641,9 @@
       }
     },
     "@elastic/eui": {
-      "version": "77.2.0",
-      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-77.2.0.tgz",
-      "integrity": "sha512-6j3jqXdRmLGQ530GtdMrXyqi7rVd/XCMhymgO+FJiamf3dw5NF1LsXiOTn2+lTa/Tn3v2sJMVsr+SL+0h2Cd+A==",
+      "version": "78.0.0",
+      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-78.0.0.tgz",
+      "integrity": "sha512-2OZVdLHpQPm8CWpOqnBI0XisohlTtsuDub1r90UTsIZCrwevK3aBrLb8DibpggRfaXXE4QtALYpN8+JoEu8dWw==",
       "requires": {
         "@types/chroma-js": "^2.0.0",
         "@types/lodash": "^4.14.160",
@@ -30667,6 +30667,7 @@
         "react-focus-on": "^3.7.0",
         "react-input-autosize": "^3.0.0",
         "react-is": "^17.0.2",
+        "react-remove-scroll-bar": "^2.3.4",
         "react-virtualized-auto-sizer": "^1.0.6",
         "react-window": "^1.8.6",
         "refractor": "^3.5.0",
@@ -48566,9 +48567,9 @@
       }
     },
     "styled-components": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.6.tgz",
-      "integrity": "sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==",
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.10.tgz",
+      "integrity": "sha512-3kSzSBN0TiCnGJM04UwO1HklIQQSXW7rCARUk+VyMR7clz8XVlA3jijtf5ypqoDIdNMKx3la4VvaPFR855SFcg==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
-    "@elastic/eui": "^77.2.0",
+    "@elastic/eui": "^78.0.0",
     "@elastic/synthetics": "=1.0.0-beta.43",
     "@emotion/cache": "^11.9.3",
     "@emotion/react": "^11.9.3",
@@ -93,7 +93,7 @@
     "playwright": "https://gitpkg.now.sh/elastic/playwright/packages/playwright-core?1.31.1-recorder",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "styled-components": "^5.3.5",
+    "styled-components": "^5.3.7",
     "typescript": "^4.5.3"
   },
   "browserslist": [


### PR DESCRIPTION
## Summary

Updates `EUI` and `styled-components` to use more recent versions.

## Implementation details

There should be no noticeable delta in terms of features or use.

## How to validate this change

Run the recorder and ensure that while smoke testing nothing seems off. If e2e tests are passing and everything looks visually ok, this is safe to merge.
