### PR TITLE
[Chore] Revert publishing release artifacts to GitHub

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -159,7 +159,7 @@ pipeline {
           steps {
             dir("${BASE_DIR}") {
               withCredentials([string(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7', variable: 'GITHUB_TOKEN')]) {
-                sh(label: 'create-github-release.sh', script: '.ci/scripts/create-github-release.sh "${SIGNED_ARTIFACTS}/${DIST_FOLDER}"')
+                sh(label: 'create-github-release.sh', script: '.ci/scripts/create-github-release.sh')
               }
             }
           }

--- a/.ci/scripts/create-github-release.sh
+++ b/.ci/scripts/create-github-release.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -eox pipefail
 
-DIST_LOCATION=$1
-
-ls -l "${DIST_LOCATION}"/*.* || true
-
 if ! gh --version &>/dev/null ; then
   ## install gh
   wget -q https://github.com/cli/cli/releases/download/v2.4.0/gh_2.4.0_macOS_amd64.tar.gz -O gh.tar.gz
@@ -19,5 +15,4 @@ gh release \
   "${TAG_NAME}" \
   --draft \
   --title "${TAG_NAME}" \
-  --repo "elastic/${REPO}" \
-  "${DIST_LOCATION}"/*.*
+  --repo "elastic/${REPO}"


### PR DESCRIPTION
## Summary

As part of https://github.com/elastic/synthetics-recorder/pull/415 we merged some changes that re-introduced artifact publishing to GitHub. After v1 release is published we will not do this anymore as we will migrate to a dedicated downloads page for the recorder. This patch simply reverts the changes we added to the CI pipeline.

Don't merge until after v1 is published.

## Implementation details

Removes code that was reintroduced in a previous patch.

## How to validate this change

You can create a draft release and verify whether or not the artifacts end up in GitHub. With this PR they shouldn't.

These instructions assume your `git remote -v` will show Elastic's fork as `upstream`, and that the tag `v0.0.1-test` does not already exist on the remote.

- Checkout the PR
- `git tag v0.0.1-test`
- `git push upstream v0.0.1-test`
- Check for an email indicating whether or not the release build succeeded. If it did, look for your tag's name in the GH repo and see if there are any artifacts. It should only include the zip for the source code.