### PR TITLE
[Chore] Update downloads page arch

### DIFF
--- a/docs/DOWNLOAD.md
+++ b/docs/DOWNLOAD.md
@@ -4,13 +4,10 @@ Current Version: 1.0 Released 18 May 2023
 
 Download Links:
 
-[MacOS (Intel)](https://download.elasticsearch.org/synthetics-recorder/synthetics-recorder-1.0.0-mac-x64.dmg)
-
-[MacOS (Apple Silicon)](https://download.elasticsearch.org/synthetics-recorder/synthetics-recorder-1.0.0-mac-arm64.dmg)
-
-[Windows](https://download.elasticsearch.org/synthetics-recorder/synthetics-recorder-1.0.0-win-x64.exe)
-
-[Linux](https://download.elasticsearch.org/synthetics-recorder/synthetics-recorder-1.0.0-linux-amd64.deb) 
+- [MacOS (Intel)](https://download.elasticsearch.org/synthetics-recorder/synthetics-recorder-1.0.0-mac-x64.dmg)
+- [MacOS (Apple Silicon)](https://download.elasticsearch.org/synthetics-recorder/synthetics-recorder-1.0.0-mac-arm64.dmg)
+- [Windows](https://download.elasticsearch.org/synthetics-recorder/synthetics-recorder-1.0.0-win-x64.exe)
+- [Linux](https://download.elasticsearch.org/synthetics-recorder/synthetics-recorder-1.0.0-linux-amd64.deb) 
 
 
 **Supported Systems:**

--- a/docs/DOWNLOAD.md
+++ b/docs/DOWNLOAD.md
@@ -16,8 +16,5 @@ Download Links:
 **Supported Systems:**
 
 - macOS (High Sierra and up): 64-bit Intel and ARM (Apple Silicon M1 & M2) for macOS. 
-- Windows (Windows 10 and up): ia32 (x86), x64 (amd64), and arm64 binaries for Windows. 
-- Linux: *Verified to work on*
-	- Ubuntu 14.04 and newer
-	- Fedora 24 and newer
-	- Debian 8 and newer
+- Windows (Windows 10 and up): x64. 
+- Linux: *Verified to work on* Ubuntu 14.04 and newer.


### PR DESCRIPTION
## Summary

For the 1.0.0 release we have a few arch options listed in the Downloads page that we don't support *yet*.

## Implementation details

Removes a few arch options that we don't support.

## How to validate this change

Review the copy and check the links are working.