### PR TITLE
Update release instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,16 +9,35 @@ Be sure you have checked out the `main` branch and have pulled the latest change
   git pull upstream main
 ```
 
-Bump the beta version
+#### Ensure package-lock.json is clean
+
+```
+# package-lock.json file should have no unstaged changes
+npm install
+```
+
+#### Run tests
+
+Ensure the tests pass for you locally.
+
+```
+npm test
+```
+
+#### Bump the project version
 
 ```bash
-  npm version prerelease --preid=beta
+  npm version minor
 ```
 
-Push commits and tags upstream
+#### Push commits and tags upstream
 
 ```
-  git push upstream main && git push upstream --tags
+  # update code
+  git push upstream main
+
+  # new tag will trigger a release build
+  git push upstream --tags
 ```
 
 This will start the release process. Wait for an email/slack to confirm the release is done.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ Be sure you have checked out the `main` branch and have pulled the latest change
 
 #### Ensure package-lock.json is clean
 
-```
+```bash
 # package-lock.json file should have no unstaged changes
 npm install
 ```
@@ -20,7 +20,7 @@ npm install
 
 Ensure the tests pass for you locally.
 
-```
+```bash
 npm test
 ```
 
@@ -32,7 +32,7 @@ npm test
 
 #### Push commits and tags upstream
 
-```
+```bash
   # update code
   git push upstream main
 


### PR DESCRIPTION
## Summary

As we are no longer in beta I have changed some of the commands we document for releasing the recorder.

I've also added new instructions that should be done as a final check before pushing a tag for a release build, namely checking package-lock and running tests locally.

## Implementation details

N/A

## How to validate this change

You could perform some of these steps locally, just don't `push upstream` anything.