### PR TITLE
Bump EUI to 84.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@elastic/datemath": "^5.0.3",
-        "@elastic/eui": "^82.1.0",
+        "@elastic/eui": "^84.0.0",
         "@elastic/synthetics": "^1.2.0",
         "@emotion/cache": "^11.9.3",
         "@emotion/react": "^11.9.3",
@@ -2645,9 +2645,9 @@
       }
     },
     "node_modules/@elastic/eui": {
-      "version": "82.1.0",
-      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-82.1.0.tgz",
-      "integrity": "sha512-Y5zuPm4/n3dKKc0yxJxoq8m4UfjumKPixW5CCtKwFgjaZFw4RICDuNCkS11oSMQD7aYX2a1ie1EvD4OA4pa7ug==",
+      "version": "84.0.0",
+      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-84.0.0.tgz",
+      "integrity": "sha512-hgDWyXwlhpbNzQgIvGLppqSRMEVt2zMlXIxMzvlV6PYPJUh1K9f5pOyXtNyouFgYZG2bkltvG3cUrMLeBbgUkg==",
       "dependencies": {
         "@types/chroma-js": "^2.0.0",
         "@types/lodash": "^4.14.194",
@@ -2668,7 +2668,7 @@
         "react-beautiful-dnd": "^13.1.0",
         "react-dropzone": "^11.5.3",
         "react-element-to-jsx-string": "^14.3.4",
-        "react-focus-on": "^3.7.0",
+        "react-focus-on": "^3.9.1",
         "react-input-autosize": "^3.0.0",
         "react-is": "^17.0.2",
         "react-remove-scroll-bar": "^2.3.4",
@@ -2689,6 +2689,9 @@
         "url-parse": "^1.5.10",
         "uuid": "^8.3.0",
         "vfile": "^4.2.0"
+      },
+      "engines": {
+        "node": "16.x || 18.x || >=20.0"
       },
       "peerDependencies": {
         "@elastic/datemath": "^5.0.2",
@@ -6581,9 +6584,9 @@
       }
     },
     "node_modules/aria-hidden/node_modules/tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/aria-query": {
       "version": "5.1.3",
@@ -11359,9 +11362,9 @@
       }
     },
     "node_modules/focus-lock/node_modules/tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/follow-redirects": {
       "version": "1.15.2",
@@ -19602,9 +19605,9 @@
       "dev": true
     },
     "node_modules/react-focus-lock": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
-      "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.5.tgz",
+      "integrity": "sha512-h6vrdgUbsH2HeD5I7I3Cx1PPrmwGuKYICS+kB9m+32X/9xHRrAbxgvaBpG7BFBN9h3tO+C3qX1QAVESmi4CiIA==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "focus-lock": "^0.11.6",
@@ -19624,12 +19627,12 @@
       }
     },
     "node_modules/react-focus-on": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.8.1.tgz",
-      "integrity": "sha512-fQcBx+SZMgXoRL+69r5+ic4bdVgqaCeKeoFPra8yhcSuL/3unWavfdirEFBGgH71K+RiocMTS6DETHcX0SlOZg==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.9.1.tgz",
+      "integrity": "sha512-IYo2j4mgNpZEJNv+/XzZs3S3xhJbR+AFop092h4OMW7sbFpIMVWxp/Z61V/gfpsgOi7VnoSFXP2bfOWWkjjtOw==",
       "dependencies": {
         "aria-hidden": "^1.2.2",
-        "react-focus-lock": "^2.9.2",
+        "react-focus-lock": "^2.9.4",
         "react-remove-scroll": "^2.5.6",
         "react-style-singleton": "^2.2.0",
         "tslib": "^2.3.1",
@@ -19650,9 +19653,9 @@
       }
     },
     "node_modules/react-focus-on/node_modules/tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/react-input-autosize": {
       "version": "3.0.0",
@@ -19754,14 +19757,14 @@
       }
     },
     "node_modules/react-remove-scroll-bar/node_modules/tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/react-remove-scroll/node_modules/tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/react-scripts": {
       "version": "5.0.1",
@@ -21491,9 +21494,9 @@
       }
     },
     "node_modules/react-style-singleton/node_modules/tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/react-test-renderer": {
       "version": "17.0.2",
@@ -24759,9 +24762,9 @@
       }
     },
     "node_modules/use-callback-ref/node_modules/tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/use-memo-one": {
       "version": "1.1.3",
@@ -24793,9 +24796,9 @@
       }
     },
     "node_modules/use-sidecar/node_modules/tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/utf8-byte-length": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
-    "@elastic/eui": "^82.1.0",
+    "@elastic/eui": "^84.0.0",
     "@elastic/synthetics": "^1.2.0",
     "@emotion/cache": "^11.9.3",
     "@emotion/react": "^11.9.3",


### PR DESCRIPTION
## Summary

Bumps the EUI version to 84.0.0.

## Implementation details

UI should look identical to what we shipped in v1.1.0.

## How to validate this change

Run the recorder, preferably alongside the previous release version, make sure the EUI elements look the same.