### PR TITLE
Merge v1.3.0 to main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "synthetics-recorder",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "synthetics-recorder",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synthetics-recorder",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Record synthetics user journey flow of a website",
   "repository": "https://github.com/elastic/synthetics-recorder",
   "scripts": {


### PR DESCRIPTION
I am no longer capable of pushing directly to upstream `main`, so making this PR to merge the change that contains the update. I think this is ok, since the release tag is what we should go off of for the release.