### PR TITLE
chore(github-action): create test check status for docs only

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -20,6 +20,6 @@ permissions:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -1,0 +1,25 @@
+---
+# This workflow sets the Test / test status check to success in case it's a docs only PR and test.yml is not triggered
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: Test # The name must be the same as in test.yml
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore: # This expression needs to match the paths ignored on test.yml.
+      - '**'
+      - '!**/*.md'
+  pull_request:
+    paths-ignore: # This expression needs to match the paths ignored on test.yml.
+      - '**'
+      - '!**/*.md'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - run: 'echo "No build required"'


### PR DESCRIPTION
## Summary

```cucumber
Given the Test workflow (.github/workflows/test.yml) with paths-ignore
When the GitHub check status called `test` is enabled as one of the rules in the Branch protection
Then it's required to synthetically set the GitHub check status called `test` for those changes that are in the `paths-ignore'
```

## Implementation details

A new GitHub workflow that overrides the name of the GitHub check and listening for the files that have been [ignored in the test GitHub](https://github.com/elastic/synthetics-recorder/blob/a6f4b6cb915d94a74a06247e379c8a141f32af34/.github/workflows/test.yml#L6-L10) workflow.

## How to validate this change

Once it's merged

## Issues

Unblocks https://github.com/elastic/synthetics-recorder/pull/482
