### PR TITLE
ci(release): avoid interactive approach

### DIFF
--- a/.buildkite/scripts/create-github-release.sh
+++ b/.buildkite/scripts/create-github-release.sh
@@ -38,9 +38,9 @@ if [ -n "${BUILDKITE_TAG}" ] ; then
     create \
     "${BUILDKITE_TAG}" \
     --draft \
-    --title "${BUILDKITE_TAG}" \
-    --repo elastic/synthetics-recorder \
-    ./$DIST_LOCATION/*.*
+    --generate-notes \
+    --repo "elastic/synthetics-recorder" \
+    "${DIST_LOCATION}"/*.*
 else
   echo "gh release won't be triggered this is not a Git tag release, but let's list the releases"
   # VAULT_GITHUB_TOKEN is the GitHub ephemeral token created in Buildkite


### PR DESCRIPTION
Avoid interactive gh release, according to https://github.com/cli/cli/blob/5402e207ee89f2f3dc52779c3edde632485074cd/pkg/cmd/release/create/create.go#L113-L114


```bash
BUILDKITE_TAG=1.2.3 gh release \
    create \
    "${BUILDKITE_TAG}" \
    --draft \
    --generate-notes \
    --repo v1v/synthetics-recorder 
https://github.com/v1v/synthetics-recorder/releases/tag/untagged-f847e66934fea83d4b33
```

<img width="591" alt="image" src="https://github.com/user-attachments/assets/dea4d2e5-20c0-4faa-a1e6-8afec0b01bd4" />
