### PR TITLE
Upgrade EUI to v101

### DIFF
--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -10,7 +10,7 @@ fi
 
 echo "--- Install node and gather dependencies"
 nvm install "$(cat .nvmrc)"
-npm ci
+npm ci --legacy-peer-deps
 
 echo "--- run release-ci"
 # Disable signing

--- a/.ci/scripts/release-ci.sh
+++ b/.ci/scripts/release-ci.sh
@@ -1,0 +1,26 @@
+#!/bin/bash --login
+
+set -eo pipefail
+
+echo 'set env context'
+export HOME='/var/lib/jenkins'
+export CSC_KEYCHAIN="/var/lib/jenkins/Library/Keychains/Elastic.keychain-db"
+
+echo 'set keychain'
+set -x
+security list-keychains -s "$CSC_KEYCHAIN"
+security list-keychains
+
+set +x
+echo 'unlock keychain'
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$CSC_KEYCHAIN"
+
+echo 'run release-ci'
+set -x
+npm ci --legacy-peer-deps
+
+# temp, TEAM_ID is public info that is available in codesign verification
+export APPLE_TEAM_ID='2BT3HPN62Z'
+export APPLE_USERNAME
+export APPLE_APP_SPECIFIC_PASSWORD
+npm run release-ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
       - name: Install modules
-        run: npm ci
+        run: npm ci --legacy-peer-deps
       - name: Lint
         run: npm run lint
       - name: Unused exports

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -48,7 +48,7 @@ License 2.0, unless the header specifies another license.
 
 
 EUI
-Copyright 2012-2021 Elasticsearch B.V.
+Copyright 2012-2024 Elasticsearch B.V.
 
 ---
 This product bundles code based on react-datepicker@2.0.0 which is
@@ -131,6 +131,33 @@ THE SOFTWARE.
 
 ---
 This product relies on @emotion/cache
+
+MIT License
+
+Copyright (c) Emotion team and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+
+---
+This product relies on @emotion/css
 
 MIT License
 
@@ -309,218 +336,6 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
----
-This product relies on playwright-core
-
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Portions Copyright (c) Microsoft Corporation.
-   Portions Copyright 2017 Google Inc.
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-
-Playwright
-Copyright (c) Microsoft Corporation
-
-This software contains code derived from the Puppeteer project (https://github.com/puppeteer/puppeteer),
-available under the Apache 2.0 license (https://github.com/puppeteer/puppeteer/blob/master/LICENSE).
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can see potential error outputs as a result of using the incorrect version b
 Install the dependencies
 
 ```
-npm install
+npm install --legacy-peer-deps
 ```
 
 Run the recorder app in dev mode.
@@ -179,7 +179,7 @@ Test new changes in the Recorder by updating Recorder's package.json. Update the
 
 ```bash
 # run your install to update `package-lock.json` and install your target synthetics and playwright packages
-npm install
+npm install --legacy-peer-deps
 
 # you can now run the Recorder and make sure that you can record and test journeys
 npm run dev

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,7 +13,7 @@ Be sure you have checked out the `main` branch and have pulled the latest change
 
 ```bash
 # package-lock.json file should have no unstaged changes
-npm install
+npm install --legacy-peer-deps
 ```
 
 #### Run tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,10 @@
       "license": "MIT",
       "dependencies": {
         "@elastic/datemath": "^5.0.3",
-        "@elastic/eui": "^89.1.0",
+        "@elastic/eui": "^101.1.0",
         "@elastic/synthetics": "=1.18.0",
         "@emotion/cache": "^11.9.3",
+        "@emotion/css": "^11.13.5",
         "@emotion/react": "^11.9.3",
         "dotenv": "^16.0.3",
         "electron-debug": "^3.2.0",
@@ -27,7 +28,7 @@
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "styled-components": "^6.1.0",
-        "typescript": "^4.5.3"
+        "typescript": "^5.8.2"
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
@@ -2424,65 +2425,116 @@
       }
     },
     "node_modules/@elastic/eui": {
-      "version": "89.1.0",
-      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-89.1.0.tgz",
-      "integrity": "sha512-vvSfP+kMUeQlfmxnRZhdX7r3rxpmjc3PkWC0KrMTf+NlXEao1imvlMHJNIJ58z5YjUBSMN5jtXkNkjHGI86KDw==",
+      "version": "101.1.0",
+      "resolved": "https://registry.npmjs.org/@elastic/eui/-/eui-101.1.0.tgz",
+      "integrity": "sha512-j79DBovRtzWPi9Bx/8IZ/z6suPVbflDVg5LW5dwp5ti3m0K24rLcqEwWQSv5gxHswDR4lkYIvOjbOqnfREsrqA==",
       "dependencies": {
-        "@hello-pangea/dnd": "^16.3.0",
-        "@types/lodash": "^4.14.198",
-        "@types/numeral": "^2.0.2",
-        "@types/react-window": "^1.8.5",
-        "@types/refractor": "^3.0.2",
-        "@types/resize-observer-browser": "^0.1.7",
+        "@elastic/eui-theme-common": "0.1.0",
+        "@elastic/prismjs-esql": "^1.0.0",
+        "@hello-pangea/dnd": "^16.6.0",
+        "@types/lodash": "^4.14.202",
+        "@types/numeral": "^2.0.5",
+        "@types/react-window": "^1.8.8",
+        "@types/refractor": "^3.4.0",
         "chroma-js": "^2.4.2",
-        "classnames": "^2.3.2",
+        "classnames": "^2.5.1",
         "lodash": "^4.17.21",
         "mdast-util-to-hast": "^10.2.0",
         "numeral": "^2.0.6",
-        "prop-types": "^15.6.0",
+        "prop-types": "^15.8.1",
         "react-dropzone": "^11.7.1",
         "react-element-to-jsx-string": "^15.0.0",
         "react-focus-on": "^3.9.1",
         "react-is": "^17.0.2",
         "react-remove-scroll-bar": "^2.3.4",
-        "react-virtualized-auto-sizer": "^1.0.20",
-        "react-window": "^1.8.9",
-        "refractor": "^3.5.0",
-        "rehype-raw": "^5.0.0",
+        "react-virtualized-auto-sizer": "^1.0.24",
+        "react-window": "^1.8.10",
+        "refractor": "^3.6.0",
+        "rehype-raw": "^5.1.0",
         "rehype-react": "^6.2.1",
         "rehype-stringify": "^8.0.0",
         "remark-breaks": "^2.0.2",
         "remark-emoji": "^2.1.0",
         "remark-parse-no-trim": "^8.0.4",
-        "remark-rehype": "^8.0.0",
+        "remark-rehype": "^8.1.0",
         "tabbable": "^5.3.3",
         "text-diff": "^1.0.1",
         "unified": "^9.2.2",
         "unist-util-visit": "^2.0.3",
         "url-parse": "^1.5.10",
         "uuid": "^8.3.0",
-        "vfile": "^4.2.0"
+        "vfile": "^4.2.1"
       },
       "engines": {
-        "node": "16.x || 18.x || >=20.0"
+        "node": "16.x || 18.x || >=20.x"
       },
       "peerDependencies": {
         "@elastic/datemath": "^5.0.2",
+        "@elastic/eui-theme-borealis": "0.1.0",
         "@emotion/css": "11.x",
         "@emotion/react": "11.x",
         "@types/react": "^16.9 || ^17.0 || ^18.0",
         "@types/react-dom": "^16.9 || ^17.0 || ^18.0",
         "moment": "^2.13.0",
-        "prop-types": "^15.5.0",
         "react": "^16.12 || ^17.0 || ^18.0",
         "react-dom": "^16.12 || ^17.0 || ^18.0",
-        "typescript": "~4.5.3"
+        "typescript": "~4.5.3 || ^5"
+      }
+    },
+    "node_modules/@elastic/eui-theme-borealis": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@elastic/eui-theme-borealis/-/eui-theme-borealis-0.1.0.tgz",
+      "integrity": "sha512-eoQw+IHK+R1RHjl4VEVyWY6cWovLXddGl/u7XvIyiRZk+oEiM1ksuk0ZkO9nSkTI/j+tA7Z5aRbivhLhvCGjuA==",
+      "peer": true,
+      "peerDependencies": {
+        "@elastic/eui-theme-common": "0.0.9"
+      }
+    },
+    "node_modules/@elastic/eui-theme-common": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@elastic/eui-theme-common/-/eui-theme-common-0.0.9.tgz",
+      "integrity": "sha512-nmeqi+gZruBQtDOirPIGgZh0QejrlmeZixKaaM/iQca5rQiTNHAE29sSpGFk20+//yfiDPQMFee7PQU/A4R4Ow==",
+      "peer": true,
+      "dependencies": {
+        "@types/lodash": "^4.14.202",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "@emotion/react": "11.x",
+        "react": "^16.12 || ^17.0 || ^18.0",
+        "react-dom": "^16.12 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@elastic/eui-theme-common/node_modules/@types/lodash": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
+      "peer": true
+    },
+    "node_modules/@elastic/eui/node_modules/@elastic/eui-theme-common": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@elastic/eui-theme-common/-/eui-theme-common-0.1.0.tgz",
+      "integrity": "sha512-2Pm9PeEr4QXjtL/YYM6faXbQ2Fm/mJXzV7QLBxUW8iHov70IHZy1e3xJOio0lI1IbO3S7t79EIS6J3/uNffJfA==",
+      "dependencies": {
+        "@types/lodash": "^4.14.202",
+        "chroma-js": "^2.4.2",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "@emotion/react": "11.x",
+        "react": "^16.12 || ^17.0 || ^18.0",
+        "react-dom": "^16.12 || ^17.0 || ^18.0"
       }
     },
     "node_modules/@elastic/eui/node_modules/@types/lodash": {
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
       "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg=="
+    },
+    "node_modules/@elastic/prismjs-esql": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@elastic/prismjs-esql/-/prismjs-esql-1.0.0.tgz",
+      "integrity": "sha512-kEQcj9wg7pUaFkW7m7zs0fz4cmg0kWUMQv6SyENXKvLGMecgDjNciEoN3CMg22PYURelbnhM7ii6nFv9hAr2NA=="
     },
     "node_modules/@elastic/synthetics": {
       "version": "1.18.0",
@@ -2870,7 +2922,6 @@
       "version": "11.13.5",
       "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
       "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
-      "peer": true,
       "dependencies": {
         "@emotion/babel-plugin": "^11.13.5",
         "@emotion/cache": "^11.13.5",
@@ -5730,11 +5781,6 @@
       "dependencies": {
         "@types/prismjs": "*"
       }
-    },
-    "node_modules/@types/resize-observer-browser": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.11.tgz",
-      "integrity": "sha512-cNw5iH8JkMkb3QkCoe7DaZiawbDQEUX8t7iuQaRTyLOyQCR2h+ibBD4GJt7p5yhUHrlOeL7ZtbxNHeipqNsBzQ=="
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
@@ -8763,19 +8809,6 @@
       "dependencies": {
         "glob": "^10.3.12",
         "typescript": "^5.4.3"
-      }
-    },
-    "node_modules/config-file-ts/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/confusing-browser-globals": {
@@ -26575,15 +26608,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "install:pw": "node scripts/install-pw.js",
     "postinstall": "npm run install:pw && electron-builder install-app-deps && node dev-tools/dep-info.js && npm run prepare-demo-app --legacy-peer-deps",
-    "prepare-demo-app": "npm install --prefix demo-app && npm run build --prefix demo-app",
+    "prepare-demo-app": "npm install --legacy-peer-deps --prefix demo-app && npm run build --prefix demo-app",
     "react:start": "react-scripts start",
     "react:build": "react-scripts build",
     "dev": "concurrently -k \"BROWSER=none npm run react:start\" \"npm run tsc-electron -- -w\" \"wait-on http://127.0.0.1:3000 && nodemon --exec electron build/electron/electron.js\"",
@@ -82,9 +82,10 @@
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
-    "@elastic/eui": "^89.1.0",
+    "@elastic/eui": "^101.1.0",
     "@elastic/synthetics": "=1.18.0",
     "@emotion/cache": "^11.9.3",
+    "@emotion/css": "^11.13.5",
     "@emotion/react": "^11.9.3",
     "dotenv": "^16.0.3",
     "electron-debug": "^3.2.0",
@@ -98,7 +99,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "styled-components": "^6.1.0",
-    "typescript": "^4.5.3"
+    "typescript": "^5.8.2"
   },
   "browserslist": [
     "last 1 version"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ import { useEffect, useState } from 'react';
 import { EuiCode, EuiEmptyPrompt, EuiGlobalToastList, EuiProvider } from '@elastic/eui';
 import type { Steps } from '@elastic/synthetics';
 import createCache from '@emotion/cache';
-import '@elastic/eui/dist/eui_theme_light.css';
+import '@elastic/eui/dist/eui_theme_borealis_light';
 import { Title } from './components/Header/Title';
 import { HeaderControls } from './components/Header/HeaderControls';
 import { CommunicationContext } from './contexts/CommunicationContext';


### PR DESCRIPTION
<!-- Thanks for your pull request. Please fill all of the mandatory fields in this template. That will help us get back to you sooner. -->

<!-- If it's your first time contributing to an Elastic repo, don't forget to sign our CLA at https://www.elastic.co/contributor-agreement -->

## Summary

Adds an upgrade to the version of EUI.

Also upgrades TypeScript. **NOTE** this TS upgrade will break peer dependencies for `react-scripts`. _So far_ it does not seem like there's any truly negative impact, but we should migrate off of `react-scripts` at some point if possible and opt for a lower-footprint custom server launch experience. This work has never been explored and is likely not as daunting as it initially sounds.

## Implementation details

Simply installs some upgrades.

This does now require us to use the `--legacy-peer-deps` escape hatch for calls to `npm install` or `npm ci` because this patch will break peer deps for some older packages that refuse to support TypeScript v5+.

## How to validate this change

1. Build and run the Recorder
2. Record a journey
3. Replay the journey
4. Export the journey
5. Add some custom steps and rearrange the step dividers