### PR TITLE
Bump Recorder patch version to 1.4.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "synthetics-recorder",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "synthetics-recorder",
-      "version": "1.4.13",
+      "version": "1.4.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synthetics-recorder",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "description": "Record synthetics user journey flow of a website",
   "repository": "https://github.com/elastic/synthetics-recorder",
   "scripts": {


### PR DESCRIPTION
## Summary

Simply bumps package version because we did not do this in a previous PR.