### PR TITLE
ci: move from dependabot reviewers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/workflows @elastic/observablt-ci

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,6 @@ updates:
   # GitHub actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    reviewers:
-      - "elastic/observablt-ci"
     schedule:
       interval: "weekly"
       day: "sunday"


### PR DESCRIPTION
<!-- Thanks for your pull request. Please fill all of the mandatory fields in this template. That will help us get back to you sooner. -->

<!-- If it's your first time contributing to an Elastic repo, don't forget to sign our CLA at https://www.elastic.co/contributor-agreement -->

## Summary
Reviewers dependabot.yml configuration is being retired option because the functionality overlaps with [GitHub code owners](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
See: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
<!-- What does this change do? Which issue does it solve? -->

<!-- If you have any screenshots or GIFs, here's where you should include them. -->

## Implementation details
Removed reviewers section in dependabot.yml and moved it's definition to CODEOWNERS.
<!-- If you're solving a bug, what caused it, and how did you fix it? -->

<!-- If you're adding a feature or implementing an enhancement, what are notable aspects about its implementation? -->

## How to validate this change

<!-- How can others validate that what you've done is correct? -->

<!-- Is there any particular subject on which you need more input? -->
