### PR TITLE
Add buildkite access for actionable-obs-team

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -36,5 +36,7 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         uptime:
           access_level: MANAGE_BUILD_AND_READ
+        actionable-obs-team:
+          access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY


### PR DESCRIPTION
<!-- Thanks for your pull request. Please fill all of the mandatory fields in this template. That will help us get back to you sooner. -->

<!-- If it's your first time contributing to an Elastic repo, don't forget to sign our CLA at https://www.elastic.co/contributor-agreement -->

## Summary

Actionable observability team is responsible for maintaining script recorder and as such needs the ability to manage and retrigger builds manually when they fail, similar to the "uptime" team that has legacy access from when that was what the team was called.

## Implementation details

Just updated catalog-info file and copied the `uptime` GH team settings. I left `uptime` as it is for now, but it's a deprecated GitHub team so we could probably remove it. Although it currently grants access to a few ingest-side Synthetics folks like Vignesh, Emiliano, etc. 

## How to validate this change

Not sure we can validate. 
